### PR TITLE
Model manager has been simplified.

### DIFF
--- a/src/api/AntModelManager.ts
+++ b/src/api/AntModelManager.ts
@@ -26,10 +26,8 @@ import { IAntMultipleResultQueryManager } from './query/IAntMultipleResultQueryM
 import { IAntQueryManager } from './query/IAntQueryManager';
 import { IAntSingleResultQueryManager } from './query/IAntSingleResultQueryManager';
 
-export type QueryMapType<
-  TEntity extends IEntity,
-  TModel extends IModel
-> = Map<string, [TModel, IAntQueryManager<TEntity, TEntity|TEntity[]>]>;
+export type QueryMapType<TEntity extends IEntity> =
+  Map<string, IAntQueryManager<TEntity, TEntity|TEntity[]>>;
 
 export abstract class AntModelManager<
   TEntity extends IEntity,
@@ -54,18 +52,15 @@ export abstract class AntModelManager<
   /**
    * Queries map.
    */
-  protected _queriesMap: QueryMapType<TEntity, TModel>;
+  protected _queriesMap: QueryMapType<TEntity>;
   /**
    * Creates a new queries map.
    * @param model Model to manage.
    * @param queriesMap Queries map.
    */
-  public constructor(
-    model: TModel,
-    queriesMap: QueryMapType<TEntity, TModel>,
-  ) {
+  public constructor(model: TModel) {
     this._model = model;
-    this._queriesMap = queriesMap;
+    this._queriesMap = new Map();
   }
   /**
    * Model manager
@@ -207,17 +202,7 @@ This is probably caused by the absence of a config instance. Ensure that config 
   private _queryGetQuery<
     TResult extends TEntity|TEntity[] = TEntity|TEntity[]
   >(alias: string): IAntQueryManager<TEntity, TResult> {
-    const mapEntry = this._queriesMap.get(alias);
-    if (undefined === mapEntry) {
-      return undefined;
-    } else {
-      const [model, query] = mapEntry;
-      if (this._model === model) {
-        return query as IAntQueryManager<TEntity, TResult>;
-      } else {
-        throw new Error('The query found manages a different model than the model managed by this manager.');
-      }
-    }
+    return this._queriesMap.get(alias) as IAntQueryManager<TEntity, TResult>;
   }
   /**
    * Adds a query to the manager.
@@ -260,7 +245,7 @@ This is probably caused by the absence of a config instance. Ensure that config 
     }
     if (null != aliasOrNothing) {
       if (undefined === this._queriesMap.get(aliasOrNothing)) {
-        this._queriesMap.set(aliasOrNothing, [this._model, query]);
+        this._queriesMap.set(aliasOrNothing, query);
       } else {
         throw new Error('There is already a query with this alias');
       }

--- a/src/test/api/AntModelManagerTest.ts
+++ b/src/test/api/AntModelManagerTest.ts
@@ -40,7 +40,6 @@ export class AntModelManagerTest implements ITest {
       this._itMustGetAndSetMultipleResultQuery();
       this._itMustGetAndSetSingleResultQuery();
       this._itMustSetAQueryWithoutAlias();
-      this._itMustNotGetQueryIfQueryOfADifferentModelAlreadyExists();
       this._itMustNotSetConfigIfConfigAlreadyExists();
       this._itMustNotSetQueryIfQueryWithTheSameAliasIsRegistered();
       this._itMustReturnUndefinedIfTheAliasDoesNotExist();
@@ -55,7 +54,7 @@ export class AntModelManagerTest implements ITest {
       const model = modelGenerator(prefix);
       expect(() => {
         // tslint:disable-next-line:no-unused-expression
-        new MinimalAntModelManager(model, new Map());
+        new MinimalAntModelManager(model);
       }).not.toThrowError();
       done();
     }, MAX_SAFE_TIMEOUT);
@@ -66,7 +65,7 @@ export class AntModelManagerTest implements ITest {
     const prefix = this._declareName + '/' + itsName + '/';
     it(itsName, async (done) => {
       const model = modelGenerator(prefix);
-      const antModelManager = new MinimalAntModelManager(model, new Map());
+      const antModelManager = new MinimalAntModelManager(model);
       antModelManager.config({
         redis: this._redis.redis,
       });
@@ -126,7 +125,7 @@ export class AntModelManagerTest implements ITest {
     const prefix = this._declareName + '/' + itsName + '/';
     it(itsName, async (done) => {
       const model = modelGenerator(prefix);
-      const antModelManager = new MinimalAntModelManager(model, new Map());
+      const antModelManager = new MinimalAntModelManager(model);
       const config = {
         redis: this._redis.redis,
       };
@@ -142,7 +141,7 @@ export class AntModelManagerTest implements ITest {
     const prefix = this._declareName + '/' + itsName + '/';
     it(itsName, async (done) => {
       const model = modelGenerator(prefix);
-      const antModelManager = new MinimalAntModelManager(model, new Map());
+      const antModelManager = new MinimalAntModelManager(model);
       const config = {
         redis: this._redis.redis,
       };
@@ -171,7 +170,7 @@ export class AntModelManagerTest implements ITest {
     const prefix = this._declareName + '/' + itsName + '/';
     it(itsName, async (done) => {
       const model = modelGenerator(prefix);
-      const antModelManager = new MinimalAntModelManager(model, new Map());
+      const antModelManager = new MinimalAntModelManager(model);
       const config = {
         redis: this._redis.redis,
       };
@@ -201,7 +200,7 @@ export class AntModelManagerTest implements ITest {
     const prefix = this._declareName + '/' + itsName + '/';
     it(itsName, async (done) => {
       const model = modelGenerator(prefix);
-      const antModelManager = new MinimalAntModelManager(model, new Map());
+      const antModelManager = new MinimalAntModelManager(model);
       const config = {
         redis: this._redis.redis,
       };
@@ -225,32 +224,12 @@ export class AntModelManagerTest implements ITest {
     }, MAX_SAFE_TIMEOUT);
   }
 
-  private _itMustNotGetQueryIfQueryOfADifferentModelAlreadyExists(): void {
-    const itsName = 'mustNotGetQueryIfQueryOfADifferentModelAlreadyExists';
-    const prefix = this._declareName + '/' + itsName + '/';
-    it(itsName, async (done) => {
-      const model = modelGenerator(prefix);
-      const queriesMap = new Map();
-      const queryAlias = 'query-alias';
-      queriesMap.set(queryAlias, [{id: 'id'}, null]);
-      const antModelManager = new MinimalAntModelManager(model, queriesMap);
-      const config = {
-        redis: this._redis.redis,
-      };
-      antModelManager.config(config);
-      expect(() => {
-        antModelManager.query(queryAlias);
-      }).toThrowError();
-      done();
-    }, MAX_SAFE_TIMEOUT);
-  }
-
   private _itMustNotSetConfigIfConfigAlreadyExists(): void {
     const itsName = 'mustNotSetConfigIfConfigAlreadyExists';
     const prefix = this._declareName + '/' + itsName + '/';
     it(itsName, async (done) => {
       const model = modelGenerator(prefix);
-      const antModelManager = new MinimalAntModelManager(model, new Map());
+      const antModelManager = new MinimalAntModelManager(model);
       const config = {
         redis: this._redis.redis,
       };
@@ -266,7 +245,7 @@ export class AntModelManagerTest implements ITest {
     const prefix = this._declareName + '/' + itsName + '/';
     it(itsName, async (done) => {
       const model = modelGenerator(prefix);
-      const antModelManager = new MinimalAntModelManager(model, new Map());
+      const antModelManager = new MinimalAntModelManager(model);
       const config = {
         redis: this._redis.redis,
       };
@@ -298,7 +277,7 @@ export class AntModelManagerTest implements ITest {
     const prefix = this._declareName + '/' + itsName + '/';
     it(itsName, async (done) => {
       const model = modelGenerator(prefix);
-      const antModelManager = new MinimalAntModelManager(model, new Map());
+      const antModelManager = new MinimalAntModelManager(model);
       const config = {
         redis: this._redis.redis,
       };
@@ -313,7 +292,7 @@ export class AntModelManagerTest implements ITest {
     const prefix = this._declareName + '/' + itsName + '/';
     it(itsName, async (done) => {
       const model = modelGenerator(prefix);
-      const antModelManager = new MinimalAntModelManager(model, new Map());
+      const antModelManager = new MinimalAntModelManager(model);
       const config = {
         redis: this._redis.redis,
       };

--- a/src/test/api/MinimalAntManager.ts
+++ b/src/test/api/MinimalAntManager.ts
@@ -1,5 +1,4 @@
 import { AntManager } from '../../api/AntManager';
-import { QueryMapType } from '../../api/AntModelManager';
 import { IAntModelConfig } from '../../api/config/IAntModelConfig';
 import { IAntModelManager } from '../../api/IAntModelManager';
 import { IEntity } from '../../model/IEntity';
@@ -12,16 +11,10 @@ export class MinimalAntManager extends AntManager<
   IAntModelManager<IEntity, IAntModelConfig>
 > {
   /**
-   * Queries map.
-   */
-  protected _queriesMap: QueryMapType<IEntity, IModel>;
-
-  /**
    * Creates a new minimal ant manager.
    */
   public constructor() {
     super();
-    this._queriesMap = new Map();
   }
 
   /**
@@ -30,6 +23,6 @@ export class MinimalAntManager extends AntManager<
    * @returns model manager created.
    */
   protected _createModelManager(model: IModel) {
-    return new MinimalAntModelManager(model, this._queriesMap);
+    return new MinimalAntModelManager(model);
   }
 }

--- a/src/test/api/MinimalAntModelManager.ts
+++ b/src/test/api/MinimalAntModelManager.ts
@@ -1,7 +1,4 @@
-import {
-  AntModelManager,
-  QueryMapType,
-} from '../../api/AntModelManager';
+import { AntModelManager } from '../../api/AntModelManager';
 import { IAntModelConfig } from '../../api/config/IAntModelConfig';
 import { IEntity } from '../../model/IEntity';
 import { IModel } from '../../model/IModel';
@@ -27,11 +24,8 @@ export class MinimalAntModelManager<
    * @param model Model to manage.
    * @param queriesMap Queries map.
    */
-  public constructor(
-    model: IModel,
-    queriesMap: QueryMapType<TEntity, IModel>,
-  ) {
-    super(model, queriesMap);
+  public constructor(model: IModel) {
+    super(model);
     this._modelManagerGenerator = new AntJsModelManagerGenerator(new RedisWrapper().redis);
     this._secondaryEntityManager = new SecondaryEntityManagerMock<TEntity>(model);
   }


### PR DESCRIPTION
An AntModelManager won't receive a map of queries by alias and model.
Now it's allowed to have queries with the same alias in different model managers.