### PR TITLE
Use faster map

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -53,6 +53,7 @@ testapi.nycrc.json
 
 # AntJS Tests
 /build/test
+/build/testapi/test
 
 # Prettier config
 .prettierignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,6 +238,12 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@types/ioredis": "^4.14.3",
     "@types/jasmine": "^3.5.0",
+    "@types/lodash": "^4.14.149",
     "@types/node": "^12.12.21",
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",

--- a/src/persistence/primary/query/ant-multiple-result-primary-query-manager.ts
+++ b/src/persistence/primary/query/ant-multiple-result-primary-query-manager.ts
@@ -145,14 +145,31 @@ export class AntMultipleResultPrimaryQueryManager<TEntity extends Entity>
     options: PersistencySearchOptions,
   ): Promise<TEntity[]> {
     const ids = await this._query(params);
-    const idsJSON = _.map(ids as any[], (id) => JSON.stringify(id));
     if (null != ids && ids.length > 0) {
-      this._redis.eval([this._luaSetQueryGenerator(), 2, key, this._reverseHashKey, ...idsJSON]);
+      this._redis.eval(this._getProcessQueryNotFoundBuildMSetParams(ids, key));
       return this._primaryEntityManager.mGet(ids, options);
     } else {
       this._redis.eval(this._luaSetVoidQueryGenerator(), 1, key);
       return new Array();
     }
+  }
+
+  /**
+   * Creates a param array to assign ids to a cached query entry.
+   * @param ids Entity ids.
+   * @param key Query key.
+   * @returns Param array generated.
+   */
+  private _getProcessQueryNotFoundBuildMSetParams(ids: number[] | string[], key: string): Array<number | string> {
+    const evalParams = new Array(ids.length + 4);
+    evalParams[0] = this._luaSetQueryGenerator();
+    evalParams[1] = 2;
+    evalParams[2] = key;
+    evalParams[3] = this._reverseHashKey;
+    for (let i = 0; i < ids.length; ++i) {
+      evalParams[i + 4] = JSON.stringify(ids[i]);
+    }
+    return evalParams;
   }
 
   /**
@@ -341,9 +358,10 @@ end`;
     if (0 === currentIds.length) {
       evalParams.push(VOID_RESULT_STRING);
     } else {
-      finalIds.push(...(currentIds as never[]));
-      const mappedIds = _.map(currentIds as any[], (id) => JSON.stringify(id));
-      evalParams.push(...mappedIds);
+      for (const id of currentIds) {
+        (finalIds as Array<number | string>).push(id);
+        evalParams.push(JSON.stringify(id));
+      }
     }
   }
 }

--- a/src/persistence/primary/query/ant-multiple-result-primary-query-manager.ts
+++ b/src/persistence/primary/query/ant-multiple-result-primary-query-manager.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { SEPARATOR_STRING, VOID_RESULT_STRING } from '../lua-constants';
 import { AntPrimaryQueryManager } from './ant-primary-query-manager';
 import { Entity } from '../../../model/entity';
@@ -52,7 +53,7 @@ export class AntMultipleResultPrimaryQueryManager<TEntity extends Entity>
     if (null == paramsArray || 0 === paramsArray.length) {
       return new Array();
     }
-    const keys = paramsArray.map((params: any) => this.queryKeyGen(params));
+    const keys = _.map(paramsArray, this.queryKeyGen.bind(this));
     const luaScript = this._luaMGetGenerator();
     const resultsJson: string[] = await this._redis.eval(luaScript, keys.length, ...keys);
 
@@ -144,7 +145,7 @@ export class AntMultipleResultPrimaryQueryManager<TEntity extends Entity>
     options: PersistencySearchOptions,
   ): Promise<TEntity[]> {
     const ids = await this._query(params);
-    const idsJSON = (ids as any[]).map((id) => JSON.stringify(id));
+    const idsJSON = _.map(ids as any[], (id) => JSON.stringify(id));
     if (null != ids && ids.length > 0) {
       this._redis.eval([this._luaSetQueryGenerator(), 2, key, this._reverseHashKey, ...idsJSON]);
       return this._primaryEntityManager.mGet(ids, options);
@@ -341,7 +342,7 @@ end`;
       evalParams.push(VOID_RESULT_STRING);
     } else {
       finalIds.push(...(currentIds as never[]));
-      const mappedIds = (currentIds as any[]).map((id) => JSON.stringify(id));
+      const mappedIds = _.map(currentIds as any[], (id) => JSON.stringify(id));
       evalParams.push(...mappedIds);
     }
   }

--- a/src/persistence/primary/query/ant-primary-query-manager.ts
+++ b/src/persistence/primary/query/ant-primary-query-manager.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { BasePrimaryQueryManager, PrimaryQueryManager } from './primary-query-manager';
 import { QueryResult, TMQuery, TQuery, TResult } from './query-types';
 import { Entity } from '../../../model/entity';
@@ -115,7 +116,7 @@ export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResul
    * @param query query to manage.
    */
   private _getDefaultMQuery(query: TQuery<TQueryResult>): TMQuery<TQueryResult> {
-    return (paramsArray: any[]): Promise<TQueryResult[]> => Promise.all(paramsArray.map((params) => query(params)));
+    return (paramsArray: any[]): Promise<TQueryResult[]> => Promise.all(_.map(paramsArray, query));
   }
 
   /**

--- a/src/test/api/ant-model-manager-test.ts
+++ b/src/test/api/ant-model-manager-test.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { AntModel } from '../../model/ant-model';
 import { AntQueryManager } from '../../api/query/ant-query-manager';
 import { Entity } from '../../model/entity';
@@ -150,9 +151,11 @@ export class AntModelManagerTest implements Test {
           isMultiple: true,
           query: (params: any): Promise<number[]> =>
             Promise.resolve(
-              (antModelManager.secondaryModelManager.store as Array<{ id: number; field: string }>)
-                .filter((entity) => params.field === entity.field)
-                .map((entity) => entity.id),
+              _.map(
+                (antModelManager.secondaryModelManager.store as Array<{ id: number; field: string }>)
+                  .filter((entity) => params.field === entity.field),
+                (entity) => entity.id,
+              ),
             ),
           queryKeyGen: (params: any): string => prefix + 'query/' + params.field,
           reverseHashKey: prefix + 'query/reverse',

--- a/src/test/api/ant-model-manager-test.ts
+++ b/src/test/api/ant-model-manager-test.ts
@@ -152,8 +152,9 @@ export class AntModelManagerTest implements Test {
           query: (params: any): Promise<number[]> =>
             Promise.resolve(
               _.map(
-                (antModelManager.secondaryModelManager.store as Array<{ id: number; field: string }>)
-                  .filter((entity) => params.field === entity.field),
+                (antModelManager.secondaryModelManager.store as Array<{ id: number; field: string }>).filter(
+                  (entity) => params.field === entity.field,
+                ),
                 (entity) => entity.id,
               ),
             ),

--- a/src/test/primary/model-manager-test.ts
+++ b/src/test/primary/model-manager-test.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { AntJsModelManagerGenerator } from '../../testapi/api/generator/antjs-model-manager-generator';
 import { AntJsUpdateOptions } from '../../persistence/primary/options/antjs-update-options';
 import { AntModel } from '../../model/ant-model';
@@ -729,7 +730,7 @@ export class ModelManagerTest implements Test {
           (params: any) =>
             new Promise((resolve) => {
               const entities = secondaryEntityManager.store.filter((entity) => params.strField === entity.strField);
-              resolve(entities.map((entity) => entity.id));
+              resolve(_.map(entities, (entity) => entity.id));
             }),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -790,7 +791,7 @@ export class ModelManagerTest implements Test {
           (params: any) =>
             new Promise((resolve) => {
               const entities = secondaryEntityManager.store.filter((entity) => params.strField === entity.strField);
-              resolve(entities.map((entity) => entity.id));
+              resolve(_.map(entities, (entity) => entity.id));
             }),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -857,7 +858,7 @@ export class ModelManagerTest implements Test {
           (params: any) =>
             new Promise((resolve) => {
               const entities = secondaryEntityManager.store.filter((entity) => params.strField === entity.strField);
-              resolve(entities.map((entity) => entity.id));
+              resolve(_.map(entities, (entity) => entity.id));
             }),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -939,7 +940,7 @@ export class ModelManagerTest implements Test {
           (params: any) =>
             new Promise((resolve) => {
               const entities = secondaryEntityManager.store.filter((entity) => params.strField === entity.strField);
-              resolve(entities.map((entity) => entity.id));
+              resolve(_.map(entities, (entity) => entity.id));
             }),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,

--- a/src/test/primary/query/names-starting-by-letter-alternative.ts
+++ b/src/test/primary/query/names-starting-by-letter-alternative.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
@@ -41,9 +42,11 @@ export class NamesStartingByLetterAlternative extends AntMultipleResultPrimaryQu
     super(
       (params: any) =>
         Promise.resolve(
-          secondaryModelManagerMock.store
-            .filter((entity) => entity.name.startsWith(params.name[0]))
-            .map((entity) => entity.id),
+          _.map(
+            secondaryModelManagerMock.store
+              .filter((entity) => entity.name.startsWith(params.name[0])),
+            (entity) => entity.id,
+          ),
         ),
       primaryEntityManager,
       redis,

--- a/src/test/primary/query/names-starting-by-letter-alternative.ts
+++ b/src/test/primary/query/names-starting-by-letter-alternative.ts
@@ -43,8 +43,7 @@ export class NamesStartingByLetterAlternative extends AntMultipleResultPrimaryQu
       (params: any) =>
         Promise.resolve(
           _.map(
-            secondaryModelManagerMock.store
-              .filter((entity) => entity.name.startsWith(params.name[0])),
+            secondaryModelManagerMock.store.filter((entity) => entity.name.startsWith(params.name[0])),
             (entity) => entity.id,
           ),
         ),

--- a/src/test/primary/query/names-starting-by-letter.ts
+++ b/src/test/primary/query/names-starting-by-letter.ts
@@ -43,10 +43,9 @@ export class NamesStartingByLetter extends AntMultipleResultPrimaryQueryManager<
       (params: any) =>
         Promise.resolve(
           _.map(
-              secondaryModelManagerMock.store
-                .filter((entity) => entity.name.startsWith(params.name[0])),
-              (entity) => entity.id
-          )
+            secondaryModelManagerMock.store.filter((entity) => entity.name.startsWith(params.name[0])),
+            (entity) => entity.id,
+          ),
         ),
       primaryEntityManager,
       redis,

--- a/src/test/primary/query/names-starting-by-letter.ts
+++ b/src/test/primary/query/names-starting-by-letter.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
@@ -41,9 +42,11 @@ export class NamesStartingByLetter extends AntMultipleResultPrimaryQueryManager<
     super(
       (params: any) =>
         Promise.resolve(
-          secondaryModelManagerMock.store
-            .filter((entity) => entity.name.startsWith(params.name[0]))
-            .map((entity) => entity.id),
+          _.map(
+              secondaryModelManagerMock.store
+                .filter((entity) => entity.name.startsWith(params.name[0])),
+              (entity) => entity.id
+          )
         ),
       primaryEntityManager,
       redis,

--- a/src/testapi/api/generator/model-manager-generator.ts
+++ b/src/testapi/api/generator/model-manager-generator.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { AntSingleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-single-result-primary-query-manager';
 import { ApiModelManagerGeneratorOptions } from './api-model-manager-generator-options';
@@ -170,7 +171,7 @@ export abstract class ModelManagerGenerator<
       const queryManager = new AntMultipleResultPrimaryQueryManager(
         (params: any) =>
           this._searchEntitiesByProperty(secondaryManager, property, params[property]).then((entities) =>
-            entities.map((entity) => entity[options.model.id]),
+            _.map(entities, (entity) => entity[options.model.id]),
           ),
         modelManager,
         options.redisOptions.redis,


### PR DESCRIPTION
This library has several bad uses of Array.map.

Array.map should not be used to generate an array and then applying an spread operator to it. Array.map can be replaced by _.map if the input is not an sparse array.

This PR replaces those bad usages of Array.map in order to get performance for free.