### PR TITLE
Add secondary delete

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -54,6 +54,7 @@
     "prefer-arrow-callback": "error",
     "prefer-promise-reject-errors": "error",
     "quotes": [ "error", "single", { "avoidEscape": true } ],
+    "semi": "error",
     "sort-imports": "error",
     "sort-keys": "error",
     "sort-vars": "error"

--- a/src/api/ant-model-manager.ts
+++ b/src/api/ant-model-manager.ts
@@ -143,9 +143,9 @@ export abstract class AntModelManager<
         queryConfig.entityKeyGen,
         queryConfig.mQuery as TMQuery<number[] | string[]>,
       );
-      query = (new AntMultipleResultQueryManager<TEntity>(
-        innerQueryManager,
-      ) as ApiMultipleResultQueryManager<TEntity>) as TAntQueryManager<TEntity, TResult>;
+      query = (new AntMultipleResultQueryManager<TEntity>(innerQueryManager) as ApiMultipleResultQueryManager<
+        TEntity
+      >) as TAntQueryManager<TEntity, TResult>;
     } else {
       const innerQueryManager = this._scheduledManager.addSingleResultQuery(
         queryConfig.query as TQuery<number | string>,
@@ -155,9 +155,9 @@ export abstract class AntModelManager<
         queryConfig.entityKeyGen,
         queryConfig.mQuery as TMQuery<number | string>,
       );
-      query = (new AntSingleResultQueryManager<TEntity>(
-        innerQueryManager,
-      ) as ApiSingleResultQueryManager<TEntity>) as TAntQueryManager<TEntity, TResult>;
+      query = (new AntSingleResultQueryManager<TEntity>(innerQueryManager) as ApiSingleResultQueryManager<
+        TEntity
+      >) as TAntQueryManager<TEntity, TResult>;
     }
     return query;
   }

--- a/src/api/ant-model-manager.ts
+++ b/src/api/ant-model-manager.ts
@@ -12,15 +12,14 @@ import { Entity } from '../model/entity';
 import { Model } from '../model/model';
 import { PersistencyDeleteOptions } from '../persistence/primary/options/persistency-delete-options';
 import { PersistencySearchOptions } from '../persistence/primary/options/persistency-search-options';
-import { PersistencyUpdateOptions } from '../persistence/primary/options/persistency-update-options';
-import { PrimaryModelManager } from '../persistence/primary/primary-model-manager';
 import { PrimaryQueryManager } from '../persistence/primary/query/primary-query-manager';
+import { SchedulerModelManager } from '../persistence/scheduler/scheduler-model-manager';
 
 export abstract class AntModelManager<
   TEntity extends Entity,
   TConfig extends ApiModelConfig,
   TModel extends Model<TEntity>,
-  TModelManager extends PrimaryModelManager<TEntity>
+  TScheduledManager extends SchedulerModelManager<TEntity, TModel>
 > implements ApiModelManager<TEntity, TConfig> {
   /**
    * AntJS model config.
@@ -31,9 +30,9 @@ export abstract class AntModelManager<
    */
   protected _model: TModel;
   /**
-   * AntJS model manager
+   * Scheduled manager
    */
-  protected _modelManager: TModelManager;
+  protected _scheduledManager: TScheduledManager;
   /**
    * Creates a new queries map.
    * @param model Model to manage.
@@ -42,18 +41,14 @@ export abstract class AntModelManager<
   public constructor(model: TModel) {
     this._model = model;
   }
-  /**
-   * Model manager
-   */
-  protected get modelManager(): TModelManager {
-    if (!this._modelManager) {
-      throw new Error(
-        `The current action could not be performed because the model manager is not ready.
-This is probably caused by the absence of a config instance. Ensure that config is set.`,
-      );
+
+  protected get scheduledManager(): TScheduledManager {
+    if (!this._scheduledManager) {
+      this._throwMissingConfigError();
     }
-    return this._modelManager;
+    return this._scheduledManager;
   }
+
   /**
    * Gets the current AntJS model config.
    * @returns Current AntJS model config.
@@ -73,18 +68,18 @@ This is probably caused by the absence of a config instance. Ensure that config 
         throw new Error("The model manager already has a configuration. It's not possible to change it.");
       }
       this._config = config;
-      this._modelManager = this._generateModelManager(this._model, this._config);
+      this._scheduledManager = this._generateScheduledManager(this._model, this._config);
       return this;
     }
   }
   /**
-   * Deletes an entity from the cache layer.
+   * Deletes an entity.
    * @param id id of the entity to delete.
    * @param options Delete options.
    * @returns Promise of entity deleted.
    */
-  public delete(id: number | string, options?: PersistencyDeleteOptions): Promise<any> {
-    return this.modelManager.delete(id, options);
+  public async delete(id: number | string, options?: PersistencyDeleteOptions): Promise<any> {
+    return this.scheduledManager.delete(id, options);
   }
   /**
    * Finds an entity by its id.
@@ -93,16 +88,16 @@ This is probably caused by the absence of a config instance. Ensure that config 
    * @returns Entity found
    */
   public get(id: string | number, options?: PersistencySearchOptions): Promise<TEntity> {
-    return this.modelManager.get(id, options);
+    return this.scheduledManager.get(id, options);
   }
   /**
-   * Deletes multiple entities from the cache layer.
+   * Deletes multiple entities.
    * @param ids Ids of the entities to delete.
    * @param options Delete options.
    * @returns Promise of entities deleted.
    */
-  public mDelete(ids: number[] | string[], options?: PersistencyDeleteOptions): Promise<any> {
-    return this.modelManager.mDelete(ids, options);
+  public async mDelete(ids: number[] | string[], options?: PersistencyDeleteOptions): Promise<any> {
+    return this.scheduledManager.mDelete(ids, options);
   }
   /**
    * Finds a collection if entities by its ids.
@@ -111,16 +106,7 @@ This is probably caused by the absence of a config instance. Ensure that config 
    * @returns Entities found.
    */
   public mGet(ids: number[] | string[], options?: PersistencySearchOptions): Promise<TEntity[]> {
-    return this.modelManager.mGet(ids, options);
-  }
-  /**
-   * Updates multiple entities at the cache layer.
-   * @param entities Entities to be updated.
-   * @param options Update options.
-   * @returns Priomise of entities updated.
-   */
-  public mUpdate(entities: TEntity[], options?: PersistencyUpdateOptions): Promise<any> {
-    return this.modelManager.mUpdate(entities, options);
+    return this.scheduledManager.mGet(ids, options);
   }
 
   /**
@@ -133,21 +119,15 @@ This is probably caused by the absence of a config instance. Ensure that config 
   ): TAntQueryManager<TEntity, TResult> {
     return this._querySetQuery(queryConfig);
   }
+
   /**
-   * Updates an entity at the cache layer.
-   * @param entity Entitty to update.
-   * @param options Update options.
-   * @returns Promise of entity updated.
-   */
-  public update(entity: TEntity, options?: PersistencyUpdateOptions): Promise<any> {
-    return this.modelManager.update(entity, options);
-  }
-  /**
-   * Generates a new model manager.
+   * Generates a new scheduled manager.
    * @param model Model of the manager.
    * @param config Manager config.
+   * @returns Scheduled manager generated.
    */
-  protected abstract _generateModelManager(model: TModel, config: TConfig): TModelManager;
+  protected abstract _generateScheduledManager(model: TModel, config: TConfig): TScheduledManager;
+
   /**
    * Adds a query to the manager.
    * @param query Query to set.
@@ -161,7 +141,7 @@ This is probably caused by the absence of a config instance. Ensure that config 
     if (queryConfig.isMultiple) {
       innerQueryManager = new AntMultipleResultPrimaryQueryManager<TEntity>(
         queryConfig.query as TQuery<number[] | string[]>,
-        this.modelManager,
+        this.scheduledManager,
         this._config.redis,
         queryConfig.reverseHashKey,
         queryConfig.queryKeyGen,
@@ -174,7 +154,7 @@ This is probably caused by the absence of a config instance. Ensure that config 
     } else {
       innerQueryManager = new AntSingleResultPrimaryQueryManager<TEntity>(
         queryConfig.query as TQuery<number | string>,
-        this.modelManager,
+        this.scheduledManager,
         this._config.redis,
         queryConfig.reverseHashKey,
         queryConfig.queryKeyGen,
@@ -186,7 +166,17 @@ This is probably caused by the absence of a config instance. Ensure that config 
       ) as ApiSingleResultQueryManager<TEntity>) as TAntQueryManager<TEntity, TResult>;
     }
 
-    this.modelManager.addQuery(innerQueryManager);
+    this.scheduledManager.addQuery(innerQueryManager);
     return query;
+  }
+
+  /**
+   * Throws a missing config error;
+   */
+  private _throwMissingConfigError(): never {
+    throw new Error(
+      `The current action could not be performed because the model manager is not ready.
+This is probably caused by the absence of a config instance. Ensure that config is set.`,
+    );
   }
 }

--- a/src/api/api-model-manager.ts
+++ b/src/api/api-model-manager.ts
@@ -3,8 +3,8 @@ import { ApiModelConfig } from './config/api-model-config';
 import { ApiMultipleResultQueryManager } from './query/api-multiple-result-query-manager';
 import { ApiQueryConfig } from './config/api-query-config';
 import { ApiSingleResultQueryManager } from './query/api-single-result-query-manager';
-import { BasePrimaryModelManager } from '../persistence/primary/primary-model-manager';
 import { Entity } from '../model/entity';
+import { SchedulerModelManagerBase } from '../persistence/scheduler/scheduler-model-manager';
 
 export type TAntQueryManager<TEntity, TQueryResult> = TQueryResult extends MultipleQueryResult
   ? ApiMultipleResultQueryManager<TEntity>
@@ -13,7 +13,7 @@ export type TAntQueryManager<TEntity, TQueryResult> = TQueryResult extends Multi
   : never;
 
 export interface ApiModelManager<TEntity extends Entity, TConfig extends ApiModelConfig>
-  extends BasePrimaryModelManager<TEntity> {
+  extends SchedulerModelManagerBase<TEntity> {
   /**
    * Gets the AntJS model config.
    * @returns AntJS model config.

--- a/src/persistence/primary/ant-primary-entity-manager.ts
+++ b/src/persistence/primary/ant-primary-entity-manager.ts
@@ -2,7 +2,6 @@ import * as _ from 'lodash';
 import { AntJsSearchOptions } from './options/antjs-search-options';
 import { CacheMode } from './options/cache-mode';
 import { Entity } from '../../model/entity';
-import { KeyGenParams } from '../../model/key-gen-params';
 import { Model } from '../../model/model';
 import { PersistencyDeleteOptions } from './options/persistency-delete-options';
 import { PersistencySearchOptions } from './options/persistency-search-options';
@@ -61,7 +60,7 @@ export class AntPrimaryEntityManager<TEntity extends Entity, TSecondaryManager e
   /**
    * Model managed.
    */
-  public get model(): Model<TEntity> {
+  protected get model(): Model<TEntity> {
     return this._model;
   }
 
@@ -186,10 +185,7 @@ export class AntPrimaryEntityManager<TEntity extends Entity, TSecondaryManager e
     if (0 === ids.length) {
       return Promise.resolve(new Array());
     }
-    return this._innerGetByDistinctIdsNotMapped(
-      ids,
-      options,
-    );
+    return this._innerGetByDistinctIdsNotMapped(ids, options);
   }
 
   /**
@@ -226,19 +222,6 @@ export class AntPrimaryEntityManager<TEntity extends Entity, TSecondaryManager e
     await this._innerGetByDistinctIdsNotMappedProcessMissingIds(missingIds, results, options);
 
     return results;
-  }
-
-  /**
-   * Creates a function that creates a lua script to create an entity key from an id.
-   * @param keyGenParams Key generation params.
-   */
-  protected _innerGetKeyGenerationLuaScriptGenerator(keyGenParams: KeyGenParams): (alias: string) => string {
-    const instructions = new Array<(alias: string) => string>();
-    instructions.push(() => '"' + keyGenParams.prefix + '" .. ');
-    instructions.push((alias) => alias);
-    return (alias: string): string => {
-      return instructions.reduce((previousValue, currentValue) => previousValue + currentValue(alias), '');
-    };
   }
 
   /**
@@ -305,7 +288,7 @@ end`;
     options: PersistencyUpdateOptions,
     keyExpression: string,
     entityExpression: string,
-    ttlExpression = 'ttl',
+    ttlExpression: string,
   ): string {
     switch (options.cacheMode) {
       case CacheMode.CacheAndOverwrite:

--- a/src/persistence/primary/lua-key-generator.ts
+++ b/src/persistence/primary/lua-key-generator.ts
@@ -5,7 +5,7 @@ import { KeyGenParams } from '../../model/key-gen-params';
  * @param keyGenParams Key generation params.
  * @returns function that creates lua code to generate a key from an id.
  */
-export const luaKeyGenerator = (keyGenParams: KeyGenParams): (alias: string) => string => {
+export const luaKeyGenerator = (keyGenParams: KeyGenParams): ((alias: string) => string) => {
   return (alias: string): string => {
     return '"' + keyGenParams.prefix + '" .. ' + alias;
   };

--- a/src/persistence/primary/lua-key-generator.ts
+++ b/src/persistence/primary/lua-key-generator.ts
@@ -1,0 +1,12 @@
+import { KeyGenParams } from '../../model/key-gen-params';
+
+/**
+ * Creates a function that creates a lua script to create an entity key from an id.
+ * @param keyGenParams Key generation params.
+ * @returns function that creates lua code to generate a key from an id.
+ */
+export const luaKeyGenerator = (keyGenParams: KeyGenParams): (alias: string) => string => {
+  return (alias: string): string => {
+    return '"' + keyGenParams.prefix + '" .. ' + alias;
+  };
+};

--- a/src/persistence/primary/primary-entity-manager.ts
+++ b/src/persistence/primary/primary-entity-manager.ts
@@ -1,8 +1,7 @@
 import { Entity } from '../../model/entity';
-import { Model } from '../../model/model';
 import { PersistencySearchOptions } from './options/persistency-search-options';
 
-export interface PrimaryEntityManagerBase<TEntity extends Entity> {
+export interface PrimaryEntityManager<TEntity extends Entity> {
   /**
    * Gets a model by its id.
    * @param id: Model's id.
@@ -17,14 +16,4 @@ export interface PrimaryEntityManagerBase<TEntity extends Entity> {
    * @returns Models found.
    */
   mGet(ids: number[] | string[], options?: PersistencySearchOptions): Promise<TEntity[]>;
-}
-
-/**
- * Represents a manager able to obtain entities by ids.
- */
-export interface PrimaryEntityManager<TEntity extends Entity> extends PrimaryEntityManagerBase<TEntity> {
-  /**
-   * Model of the manager.
-   */
-  readonly model: Model<TEntity>;
 }

--- a/src/persistence/primary/primary-entity-manager.ts
+++ b/src/persistence/primary/primary-entity-manager.ts
@@ -27,10 +27,4 @@ export interface PrimaryEntityManager<TEntity extends Entity> extends PrimaryEnt
    * Model of the manager.
    */
   readonly model: Model<TEntity>;
-
-  /**
-   * Gets the lua key generator from id.
-   * @returns Lua key generator
-   */
-  getLuaKeyGeneratorFromId(): (alias: string) => string;
 }

--- a/src/persistence/primary/primary-model-manager.ts
+++ b/src/persistence/primary/primary-model-manager.ts
@@ -1,10 +1,10 @@
-import { PrimaryEntityManager, PrimaryEntityManagerBase } from './primary-entity-manager';
 import { Entity } from '../../model/entity';
 import { PersistencyDeleteOptions } from './options/persistency-delete-options';
 import { PersistencyUpdateOptions } from './options/persistency-update-options';
+import { PrimaryEntityManager } from './primary-entity-manager';
 import { PrimaryQueryManager } from './query/primary-query-manager';
 
-export interface BasePrimaryModelManager<TEntity extends Entity> extends PrimaryEntityManagerBase<TEntity> {
+export interface BasePrimaryModelManager<TEntity extends Entity> extends PrimaryEntityManager<TEntity> {
   /**
    * Deletes an entity from the cache layer.
    * @param id id of the entity to delete.
@@ -43,10 +43,4 @@ export interface PrimaryModelManager<TEntity extends Entity>
    * @param queryManager Query manager to add.
    */
   addQuery(queryManager: PrimaryQueryManager<TEntity>): this;
-
-  /**
-   * Returns the queries managed.
-   * @returns Queries managed.
-   */
-  getQueries(): Array<PrimaryQueryManager<TEntity>>;
 }

--- a/src/persistence/primary/query/ant-multiple-result-primary-query-manager.ts
+++ b/src/persistence/primary/query/ant-multiple-result-primary-query-manager.ts
@@ -37,7 +37,7 @@ export class AntMultipleResultPrimaryQueryManager<TEntity extends Entity>
       for (const resultJson of resultsJSON) {
         this._getProcessParseableResult(key, finalResults, missingIds, resultJson);
       }
-      finalResults = this._primaryEntityManager.model.mPrimaryToEntity(finalResults);
+      finalResults = this._manager.model.mPrimaryToEntity(finalResults);
       await this._getProcessMissingOptions(missingIds, finalResults, options);
       return finalResults;
     }
@@ -73,7 +73,7 @@ export class AntMultipleResultPrimaryQueryManager<TEntity extends Entity>
       },
     );
 
-    finalResults = this._primaryEntityManager.model.mPrimaryToEntity(finalResults);
+    finalResults = this._manager.model.mPrimaryToEntity(finalResults);
 
     if (0 < missingQueriesKeys.length) {
       const queriesMissingIds = await this._mGetProcessQueriesNotFound(missingQueriesParams, missingQueriesKeys);
@@ -98,7 +98,7 @@ export class AntMultipleResultPrimaryQueryManager<TEntity extends Entity>
     options: PersistencySearchOptions,
   ): Promise<void> {
     if (0 < missingIds.length) {
-      const missingEntities = await this._primaryEntityManager.mGet(missingIds, options);
+      const missingEntities = await this._manager.mGet(missingIds, options);
       for (const missingEntity of missingEntities) {
         finalResults.push(missingEntity);
       }
@@ -147,7 +147,7 @@ export class AntMultipleResultPrimaryQueryManager<TEntity extends Entity>
     const ids = await this._query(params);
     if (null != ids && ids.length > 0) {
       this._redis.eval(this._getProcessQueryNotFoundBuildMSetParams(ids, key));
-      return this._primaryEntityManager.mGet(ids, options);
+      return this._manager.mGet(ids, options);
     } else {
       this._redis.eval(this._luaSetVoidQueryGenerator(), 1, key);
       return new Array();

--- a/src/persistence/primary/query/ant-multiple-result-primary-query-manager.ts
+++ b/src/persistence/primary/query/ant-multiple-result-primary-query-manager.ts
@@ -37,7 +37,7 @@ export class AntMultipleResultPrimaryQueryManager<TEntity extends Entity>
       for (const resultJson of resultsJSON) {
         this._getProcessParseableResult(key, finalResults, missingIds, resultJson);
       }
-      finalResults = this._manager.model.mPrimaryToEntity(finalResults);
+      finalResults = this._model.mPrimaryToEntity(finalResults);
       await this._getProcessMissingOptions(missingIds, finalResults, options);
       return finalResults;
     }
@@ -73,7 +73,7 @@ export class AntMultipleResultPrimaryQueryManager<TEntity extends Entity>
       },
     );
 
-    finalResults = this._manager.model.mPrimaryToEntity(finalResults);
+    finalResults = this._model.mPrimaryToEntity(finalResults);
 
     if (0 < missingQueriesKeys.length) {
       const queriesMissingIds = await this._mGetProcessQueriesNotFound(missingQueriesParams, missingQueriesKeys);

--- a/src/persistence/primary/query/ant-primary-query-manager.ts
+++ b/src/persistence/primary/query/ant-primary-query-manager.ts
@@ -1,15 +1,15 @@
 import * as _ from 'lodash';
-import { BasePrimaryQueryManager, PrimaryQueryManager } from './primary-query-manager';
 import { QueryResult, TMQuery, TQuery, TResult } from './query-types';
+import { BasePrimaryQueryManager } from './primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
 import { PersistencySearchOptions } from '../options/persistency-search-options';
+import { PrimaryEntityManager } from '../primary-entity-manager';
 import { RedisMiddleware } from '../redis-middleware';
-import { SchedulerModelManager } from '../../scheduler/scheduler-model-manager';
 import { luaKeyGenerator } from '../lua-key-generator';
 
 export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResult extends QueryResult>
-  implements BasePrimaryQueryManager<TEntity, TResult<TEntity, TQueryResult>>, PrimaryQueryManager<TEntity> {
+  implements BasePrimaryQueryManager<TEntity, TResult<TEntity, TQueryResult>> {
   /**
    * Entity key generator.
    */
@@ -19,13 +19,17 @@ export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResul
    */
   protected _queryKeyGen: (params: any) => string;
   /**
+   * Query model
+   */
+  protected _model: Model<TEntity>;
+  /**
    * Multiple query
    */
   protected _mquery: TMQuery<TQueryResult>;
   /**
    * Primary entity manager.
    */
-  protected _manager: SchedulerModelManager<TEntity, Model<TEntity>>;
+  protected _manager: PrimaryEntityManager<TEntity>;
   /**
    * Query to obtain ids.
    */
@@ -45,16 +49,18 @@ export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResul
 
   /**
    * Creates primary query manager.
-   * @param query Query to obtain ids.
+   * @param model Query model
    * @param manager Primary entity manager.
+   * @param query Query to obtain ids.
    * @param redis Redis connection to manage queries.
    * @param reverseHashKey Key of the reverse structure to obtain a map of entities to queries.
    * @param queryKeyGen Query key generator.
    * @param mQuery Multiple query.
    */
   public constructor(
+    model: Model<TEntity>,
+    manager: PrimaryEntityManager<TEntity>,
     query: TQuery<TQueryResult>,
-    manager: SchedulerModelManager<TEntity, Model<TEntity>>,
     redis: RedisMiddleware,
     reverseHashKey: string,
     queryKeyGen: (params: any) => string,
@@ -62,12 +68,13 @@ export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResul
     mQuery?: TMQuery<TQueryResult>,
   ) {
     this._manager = manager;
+    this._model = model;
     this._query = query;
     this._redis = redis;
     this._reverseHashKey = reverseHashKey;
     this._queryKeyGen = queryKeyGen;
     this._entityKeyGen = entityKeyGen ? entityKeyGen : queryKeyGen;
-    this._luaKeyGeneratorFromId = luaKeyGenerator(this._manager.model.keyGen);
+    this._luaKeyGeneratorFromId = luaKeyGenerator(this._model.keyGen);
 
     this._setMQuery(query, mQuery);
   }

--- a/src/persistence/primary/query/ant-primary-query-manager.ts
+++ b/src/persistence/primary/query/ant-primary-query-manager.ts
@@ -2,9 +2,10 @@ import * as _ from 'lodash';
 import { BasePrimaryQueryManager, PrimaryQueryManager } from './primary-query-manager';
 import { QueryResult, TMQuery, TQuery, TResult } from './query-types';
 import { Entity } from '../../../model/entity';
+import { Model } from '../../../model/model';
 import { PersistencySearchOptions } from '../options/persistency-search-options';
-import { PrimaryEntityManager } from '../primary-entity-manager';
 import { RedisMiddleware } from '../redis-middleware';
+import { SchedulerModelManager } from '../../scheduler/scheduler-model-manager';
 import { luaKeyGenerator } from '../lua-key-generator';
 
 export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResult extends QueryResult>
@@ -24,7 +25,7 @@ export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResul
   /**
    * Primary entity manager.
    */
-  protected _primaryEntityManager: PrimaryEntityManager<TEntity>;
+  protected _manager: SchedulerModelManager<TEntity, Model<TEntity>>;
   /**
    * Query to obtain ids.
    */
@@ -45,7 +46,7 @@ export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResul
   /**
    * Creates primary query manager.
    * @param query Query to obtain ids.
-   * @param primaryEntityManager Primary entity manager.
+   * @param manager Primary entity manager.
    * @param redis Redis connection to manage queries.
    * @param reverseHashKey Key of the reverse structure to obtain a map of entities to queries.
    * @param queryKeyGen Query key generator.
@@ -53,20 +54,20 @@ export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResul
    */
   public constructor(
     query: TQuery<TQueryResult>,
-    primaryEntityManager: PrimaryEntityManager<TEntity>,
+    manager: SchedulerModelManager<TEntity, Model<TEntity>>,
     redis: RedisMiddleware,
     reverseHashKey: string,
     queryKeyGen: (params: any) => string,
     entityKeyGen?: (entity: TEntity) => string,
     mQuery?: TMQuery<TQueryResult>,
   ) {
-    this._primaryEntityManager = primaryEntityManager;
+    this._manager = manager;
     this._query = query;
     this._redis = redis;
     this._reverseHashKey = reverseHashKey;
     this._queryKeyGen = queryKeyGen;
     this._entityKeyGen = entityKeyGen ? entityKeyGen : queryKeyGen;
-    this._luaKeyGeneratorFromId = luaKeyGenerator(this._primaryEntityManager.model.keyGen);
+    this._luaKeyGeneratorFromId = luaKeyGenerator(this._manager.model.keyGen);
 
     this._setMQuery(query, mQuery);
   }

--- a/src/persistence/primary/query/ant-primary-query-manager.ts
+++ b/src/persistence/primary/query/ant-primary-query-manager.ts
@@ -5,6 +5,7 @@ import { Entity } from '../../../model/entity';
 import { PersistencySearchOptions } from '../options/persistency-search-options';
 import { PrimaryEntityManager } from '../primary-entity-manager';
 import { RedisMiddleware } from '../redis-middleware';
+import { luaKeyGenerator } from '../lua-key-generator';
 
 export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResult extends QueryResult>
   implements BasePrimaryQueryManager<TEntity, TResult<TEntity, TQueryResult>>, PrimaryQueryManager<TEntity> {
@@ -65,7 +66,7 @@ export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResul
     this._reverseHashKey = reverseHashKey;
     this._queryKeyGen = queryKeyGen;
     this._entityKeyGen = entityKeyGen ? entityKeyGen : queryKeyGen;
-    this._luaKeyGeneratorFromId = this._primaryEntityManager.getLuaKeyGeneratorFromId();
+    this._luaKeyGeneratorFromId = luaKeyGenerator(this._primaryEntityManager.model.keyGen);
 
     this._setMQuery(query, mQuery);
   }

--- a/src/persistence/primary/query/ant-single-result-primary-query-manager.ts
+++ b/src/persistence/primary/query/ant-single-result-primary-query-manager.ts
@@ -29,7 +29,7 @@ export class AntSingleResultPrimaryQueryManager<TEntity extends Entity>
       if (null == id) {
         return null;
       } else {
-        return this._primaryEntityManager.get(id, options);
+        return this._manager.get(id, options);
       }
     } else {
       let result: TEntity | Promise<TEntity>;
@@ -37,10 +37,10 @@ export class AntSingleResultPrimaryQueryManager<TEntity extends Entity>
         key,
         resultJson,
         (entity) => {
-          result = this._primaryEntityManager.model.primaryToEntity(entity);
+          result = this._manager.model.primaryToEntity(entity);
         },
         (id: number | string) => {
-          result = this._primaryEntityManager.get(id, options);
+          result = this._manager.get(id, options);
         },
         () => {
           result = null;
@@ -85,7 +85,7 @@ export class AntSingleResultPrimaryQueryManager<TEntity extends Entity>
         },
       );
     }
-    finalResults = this._primaryEntityManager.model.mPrimaryToEntity(finalResults);
+    finalResults = this._manager.model.mPrimaryToEntity(finalResults);
     const idsFromMissingQueries = await this._mGetIdsAndSetToQueries(missingQueriesKeys, missingParamsArray);
     (missingIds as Array<number | string>).push(...idsFromMissingQueries);
     await this._mGetSearchMissingIds(finalResults, missingIds, options);
@@ -210,7 +210,7 @@ redis.call('hset', KEYS[2], ARGV[1], KEYS[1])`;
     options?: PersistencySearchOptions,
   ): Promise<void> {
     if (0 < missingIds.length) {
-      const missingEntities = await this._primaryEntityManager.mGet(missingIds, options);
+      const missingEntities = await this._manager.mGet(missingIds, options);
       for (const missingEntity of missingEntities) {
         finalResults.push(missingEntity);
       }

--- a/src/persistence/primary/query/ant-single-result-primary-query-manager.ts
+++ b/src/persistence/primary/query/ant-single-result-primary-query-manager.ts
@@ -37,7 +37,7 @@ export class AntSingleResultPrimaryQueryManager<TEntity extends Entity>
         key,
         resultJson,
         (entity) => {
-          result = this._manager.model.primaryToEntity(entity);
+          result = this._model.primaryToEntity(entity);
         },
         (id: number | string) => {
           result = this._manager.get(id, options);
@@ -85,7 +85,7 @@ export class AntSingleResultPrimaryQueryManager<TEntity extends Entity>
         },
       );
     }
-    finalResults = this._manager.model.mPrimaryToEntity(finalResults);
+    finalResults = this._model.mPrimaryToEntity(finalResults);
     const idsFromMissingQueries = await this._mGetIdsAndSetToQueries(missingQueriesKeys, missingParamsArray);
     (missingIds as Array<number | string>).push(...idsFromMissingQueries);
     await this._mGetSearchMissingIds(finalResults, missingIds, options);

--- a/src/persistence/scheduler/ant-scheduler-model-manager.ts
+++ b/src/persistence/scheduler/ant-scheduler-model-manager.ts
@@ -1,0 +1,82 @@
+import { Entity } from '../../model/entity';
+import { Model } from '../../model/model';
+import { PersistencyDeleteOptions } from '../primary/options/persistency-delete-options';
+import { PersistencySearchOptions } from '../primary/options/persistency-search-options';
+import { PrimaryModelManager } from '../primary/primary-model-manager';
+import { PrimaryQueryManager } from '../primary/query/primary-query-manager';
+import { SchedulerModelManager } from './scheduler-model-manager';
+import { SecondaryEntityManager } from '../secondary/secondary-entity-manager';
+
+export class AntScheduleModelManager<
+  TEntity extends Entity,
+  TModel extends Model<TEntity>,
+  TPrimaryManager extends PrimaryModelManager<TEntity>,
+  TSecondaryManager extends SecondaryEntityManager<TEntity>
+> implements SchedulerModelManager<TEntity, TModel> {
+  protected _model: TModel;
+  /**
+   * Primary manager
+   */
+  protected _primaryManager: TPrimaryManager;
+
+  /**
+   * Secondary manager
+   */
+  protected _secondaryManager: TSecondaryManager;
+
+  public constructor(model: TModel, primaryManager: TPrimaryManager, secondaryManager: TSecondaryManager) {
+    this._model = model;
+    this._primaryManager = primaryManager;
+    this._secondaryManager = secondaryManager;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public get model(): TModel {
+    return this._model;
+  }
+
+  /**
+   * Adds a query manager to the model manager.
+   * @param queryManager Query manager to add.
+   */
+  public addQuery(queryManager: PrimaryQueryManager<TEntity>): this {
+    this._primaryManager.addQuery(queryManager);
+    return this;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async delete(id: number | string, options?: PersistencyDeleteOptions): Promise<any> {
+    if (null != this._secondaryManager) {
+      await this._secondaryManager.delete(id);
+    }
+    return this._primaryManager.delete(id, options);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public get(id: string | number, options?: PersistencySearchOptions): Promise<TEntity> {
+    return this._primaryManager.get(id, options);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async mDelete(ids: number[] | string[], options?: PersistencyDeleteOptions): Promise<any> {
+    if (null != this._secondaryManager) {
+      await this._secondaryManager.mDelete(ids);
+    }
+    return this._primaryManager.mDelete(ids, options);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public mGet(ids: number[] | string[], options?: PersistencySearchOptions): Promise<TEntity[]> {
+    return this._primaryManager.mGet(ids, options);
+  }
+}

--- a/src/persistence/scheduler/ant-scheduler-model-manager.ts
+++ b/src/persistence/scheduler/ant-scheduler-model-manager.ts
@@ -1,11 +1,16 @@
+import { MultipleQueryResult, SingleQueryResult, TMQuery, TQuery } from '../primary/query/query-types';
+import { AntMultipleResultPrimaryQueryManager } from '../primary/query/ant-multiple-result-primary-query-manager';
+import { AntSingleResultPrimaryQueryManager } from '../primary/query/ant-single-result-primary-query-manager';
 import { Entity } from '../../model/entity';
 import { Model } from '../../model/model';
+import { MultipleResultPrimaryQueryManager } from '../primary/query/multiple-result-primary-query-manager';
 import { PersistencyDeleteOptions } from '../primary/options/persistency-delete-options';
 import { PersistencySearchOptions } from '../primary/options/persistency-search-options';
 import { PrimaryModelManager } from '../primary/primary-model-manager';
-import { PrimaryQueryManager } from '../primary/query/primary-query-manager';
+import { RedisMiddleware } from '../primary/redis-middleware';
 import { SchedulerModelManager } from './scheduler-model-manager';
 import { SecondaryEntityManager } from '../secondary/secondary-entity-manager';
+import { SingleResultPrimaryQueryManager } from '../primary/query/single-result-primary-query-manager';
 
 export class AntScheduleModelManager<
   TEntity extends Entity,
@@ -33,17 +38,51 @@ export class AntScheduleModelManager<
   /**
    * @inheritdoc
    */
-  public get model(): TModel {
-    return this._model;
+  public addMultipleResultQuery<TResult extends MultipleQueryResult>(
+    query: TQuery<TResult>,
+    redis: RedisMiddleware,
+    reverseHashKey: string,
+    queryKeyGen: (params: any) => string,
+    entityKeyGen: (entity: TEntity) => string,
+    mquery: TMQuery<TResult>,
+  ): MultipleResultPrimaryQueryManager<TEntity> {
+    const queryManager = new AntMultipleResultPrimaryQueryManager(
+      this._model,
+      this._primaryManager,
+      query,
+      redis,
+      reverseHashKey,
+      queryKeyGen,
+      entityKeyGen,
+      mquery,
+    );
+    this._primaryManager.addQuery(queryManager);
+    return queryManager;
   }
 
   /**
-   * Adds a query manager to the model manager.
-   * @param queryManager Query manager to add.
+   * @inheritdoc
    */
-  public addQuery(queryManager: PrimaryQueryManager<TEntity>): this {
+  public addSingleResultQuery<TResult extends SingleQueryResult>(
+    query: TQuery<TResult>,
+    redis: RedisMiddleware,
+    reverseHashKey: string,
+    queryKeyGen: (params: any) => string,
+    entityKeyGen: (entity: TEntity) => string,
+    mquery: TMQuery<TResult>,
+  ): SingleResultPrimaryQueryManager<TEntity> {
+    const queryManager = new AntSingleResultPrimaryQueryManager(
+      this._model,
+      this._primaryManager,
+      query,
+      redis,
+      reverseHashKey,
+      queryKeyGen,
+      entityKeyGen,
+      mquery,
+    );
     this._primaryManager.addQuery(queryManager);
-    return this;
+    return queryManager;
   }
 
   /**

--- a/src/persistence/scheduler/ant-scheduler-model-manager.ts
+++ b/src/persistence/scheduler/ant-scheduler-model-manager.ts
@@ -29,10 +29,10 @@ export class AntScheduleModelManager<
    */
   protected _secondaryManager: TSecondaryManager;
 
-  public constructor(model: TModel, primaryManager: TPrimaryManager, secondaryManager: TSecondaryManager) {
+  public constructor(model: TModel, primaryManager: TPrimaryManager, secondaryManager?: TSecondaryManager) {
     this._model = model;
     this._primaryManager = primaryManager;
-    this._secondaryManager = secondaryManager;
+    this._secondaryManager = secondaryManager ?? null;
   }
 
   /**

--- a/src/persistence/scheduler/scheduler-model-manager.ts
+++ b/src/persistence/scheduler/scheduler-model-manager.ts
@@ -1,8 +1,11 @@
+import { MultipleQueryResult, SingleQueryResult, TMQuery, TQuery } from '../primary/query/query-types';
 import { Entity } from '../../model/entity';
 import { Model } from '../../model/model';
+import { MultipleResultPrimaryQueryManager } from '../primary/query/multiple-result-primary-query-manager';
 import { PersistencyDeleteOptions } from '../primary/options/persistency-delete-options';
 import { PersistencySearchOptions } from '../primary/options/persistency-search-options';
-import { PrimaryQueryManager } from '../primary/query/primary-query-manager';
+import { RedisMiddleware } from '../primary/redis-middleware';
+import { SingleResultPrimaryQueryManager } from '../primary/query/single-result-primary-query-manager';
 
 export interface SchedulerModelManagerBase<TEntity> {
   /**
@@ -38,12 +41,39 @@ export interface SchedulerModelManagerBase<TEntity> {
 export interface SchedulerModelManager<TEntity extends Entity, TModel extends Model<TEntity>>
   extends SchedulerModelManagerBase<TEntity> {
   /**
-   * Model of the manager.
+   * Adds a single result query to the manager and returns it.
+   * @param query Single ids query handler.
+   * @param redis Redis middleware.
+   * @param reverseHashKey Redis reverse hash key.
+   * @param queryKeyGen Query key generator.
+   * @param entityKeyGen Entity key generator.
+   * @param mquery Multiple ids query handler.
+   * @returns Single query result manager generated.
    */
-  readonly model: TModel;
+  addMultipleResultQuery<TResult extends MultipleQueryResult>(
+    query: TQuery<TResult>,
+    redis: RedisMiddleware,
+    reverseHashKey: string,
+    queryKeyGen: (params: any) => string,
+    entityKeyGen: (entity: TEntity) => string,
+    mquery: TMQuery<TResult>,
+  ): MultipleResultPrimaryQueryManager<TEntity>;
   /**
-   * Adds a query manager to the model manager.
-   * @param queryManager Query manager to add.
+   * Adds a single result query to the manager and returns it.
+   * @param query Single ids query handler.
+   * @param redis Redis middleware.
+   * @param reverseHashKey Redis reverse hash key.
+   * @param queryKeyGen Query key generator.
+   * @param entityKeyGen Entity key generator.
+   * @param mquery Multiple ids query handler.
+   * @returns Single query result manager generated.
    */
-  addQuery(queryManager: PrimaryQueryManager<TEntity>): this;
+  addSingleResultQuery<TResult extends SingleQueryResult>(
+    query: TQuery<TResult>,
+    redis: RedisMiddleware,
+    reverseHashKey: string,
+    queryKeyGen: (params: any) => string,
+    entityKeyGen: (entity: TEntity) => string,
+    mquery: TMQuery<TResult>,
+  ): SingleResultPrimaryQueryManager<TEntity>;
 }

--- a/src/persistence/scheduler/scheduler-model-manager.ts
+++ b/src/persistence/scheduler/scheduler-model-manager.ts
@@ -1,0 +1,49 @@
+import { Entity } from '../../model/entity';
+import { Model } from '../../model/model';
+import { PersistencyDeleteOptions } from '../primary/options/persistency-delete-options';
+import { PersistencySearchOptions } from '../primary/options/persistency-search-options';
+import { PrimaryQueryManager } from '../primary/query/primary-query-manager';
+
+export interface SchedulerModelManagerBase<TEntity> {
+  /**
+   * Deletes an entity from the cache layer.
+   * @param id id of the entity to delete.
+   * @param options Delete options.
+   * @returns Promise of entity deleted.
+   */
+  delete(id: number | string, options?: PersistencyDeleteOptions): Promise<any>;
+  /**
+   * Gets a model by its id.
+   * @param id: Model's id.
+   * @param options Cache options.
+   * @returns Model found.
+   */
+  get(id: number | string, options?: PersistencySearchOptions): Promise<TEntity>;
+  /**
+   * Deletes multiple entities from the cache layer.
+   * @param ids Ids of the entities to delete.
+   * @param options Delete options.
+   * @returns Promise of entities deleted.
+   */
+  mDelete(ids: number[] | string[], options?: PersistencyDeleteOptions): Promise<any>;
+  /**
+   * Gets a collection of models by its ids.
+   * @param ids Model ids.
+   * @param options Cache options.
+   * @returns Models found.
+   */
+  mGet(ids: number[] | string[], options?: PersistencySearchOptions): Promise<TEntity[]>;
+}
+
+export interface SchedulerModelManager<TEntity extends Entity, TModel extends Model<TEntity>>
+  extends SchedulerModelManagerBase<TEntity> {
+  /**
+   * Model of the manager.
+   */
+  readonly model: TModel;
+  /**
+   * Adds a query manager to the model manager.
+   * @param queryManager Query manager to add.
+   */
+  addQuery(queryManager: PrimaryQueryManager<TEntity>): this;
+}

--- a/src/persistence/secondary/secondary-entity-manager.ts
+++ b/src/persistence/secondary/secondary-entity-manager.ts
@@ -6,10 +6,18 @@ export interface SecondaryEntityManager<TEntity extends Entity> {
    * Model of the manager.
    */
   readonly model: Model<TEntity>;
+
   /**
-   * Gets a model by its id.
-   * @param id: Model's id.
-   * @returns Model found.
+   * Detetes an entity by its id.
+   * @param id Entity's id.
+   * @returns Promise of entity deleted.
+   */
+  delete(id: number | string): Promise<any>;
+
+  /**
+   * Gets an entity by its id.
+   * @param id: Entity's id.
+   * @returns Entity found.
    */
   getById(id: number | string): Promise<TEntity>;
 
@@ -26,4 +34,11 @@ export interface SecondaryEntityManager<TEntity extends Entity> {
    * @returns Models found.
    */
   getByIdsOrderedAsc(ids: number[] | string[]): Promise<TEntity[]>;
+
+  /**
+   * Deletes entities from their ids.
+   * @param ids Ids of the entities to delete.
+   * @returns Promise of entities deleted.
+   */
+  mDelete(ids: string[] | number[]): Promise<any>;
 }

--- a/src/test/all-tests.ts
+++ b/src/test/all-tests.ts
@@ -1,6 +1,7 @@
 import { AntManagerTest } from './api/ant-manager-test';
 import { AntModelManagerTest } from './api/ant-model-manager-test';
 import { AntQueryManagerTest } from './api/query/ant-query-manager-test';
+import { AntSchedulerModelManagerTest } from './scheduler/ant-scheduler-mode-manager-test';
 import { AntTest } from './ant-test';
 import { LuaKeyGeneratorTest } from './primary/lua-key-generator-test';
 import { ModelManagerTest } from './primary/model-manager-test';
@@ -23,6 +24,7 @@ export class AllTest implements Test {
     new AntManagerTest(beforeAllPromise).performTests();
     new AntModelManagerTest(beforeAllPromise).performTests();
     new AntQueryManagerTest(beforeAllPromise).performTests();
+    new AntSchedulerModelManagerTest(beforeAllPromise).performTests();
     new AntTest().performTests();
     new LuaKeyGeneratorTest(beforeAllPromise).performTests();
     new ModelManagerTest(beforeAllPromise).performTests();

--- a/src/test/all-tests.ts
+++ b/src/test/all-tests.ts
@@ -2,6 +2,7 @@ import { AntManagerTest } from './api/ant-manager-test';
 import { AntModelManagerTest } from './api/ant-model-manager-test';
 import { AntQueryManagerTest } from './api/query/ant-query-manager-test';
 import { AntTest } from './ant-test';
+import { LuaKeyGeneratorTest } from './primary/lua-key-generator-test';
 import { ModelManagerTest } from './primary/model-manager-test';
 import { ModelTest } from './model/model-test';
 import { MultipleResultQueryManagerTest } from './primary/query/multiple-result-query-manager-test';
@@ -23,6 +24,7 @@ export class AllTest implements Test {
     new AntModelManagerTest(beforeAllPromise).performTests();
     new AntQueryManagerTest(beforeAllPromise).performTests();
     new AntTest().performTests();
+    new LuaKeyGeneratorTest(beforeAllPromise).performTests();
     new ModelManagerTest(beforeAllPromise).performTests();
     new ModelTest().performTests();
     new MultipleResultQueryManagerTest(beforeAllPromise).performTests();

--- a/src/test/api/ant-model-manager-test.ts
+++ b/src/test/api/ant-model-manager-test.ts
@@ -75,11 +75,9 @@ export class AntModelManagerTest implements Test {
         antModelManager.config({
           redis: this._redis.redis,
         });
-        const modelManager = antModelManager.modelManager;
+        const modelManager = antModelManager.primaryManager;
 
-        const methodsToTest = ['delete', 'get', 'mDelete', 'mGet', 'mUpdate', 'update'] as Array<
-          keyof PrimaryModelManager<any>
-        >;
+        const methodsToTest = ['delete', 'get', 'mDelete', 'mGet'] as Array<keyof PrimaryModelManager<any>>;
 
         for (const methodToTest of methodsToTest) {
           spyOn(modelManager, methodToTest as any).and.returnValue(methodToTest as any);
@@ -87,13 +85,11 @@ export class AntModelManagerTest implements Test {
 
         const entity: EntityTest = { id: 0 };
 
-        const [deleteResult, getResult, mDeleteResult, mGetResult, mUpdateResult, updateResult] = await Promise.all([
+        const [deleteResult, getResult, mDeleteResult, mGetResult] = await Promise.all([
           antModelManager.delete(entity.id),
           antModelManager.get(entity.id),
           antModelManager.mDelete([entity.id]),
           antModelManager.mGet([entity.id]),
-          antModelManager.mUpdate([entity]),
-          antModelManager.update(entity),
         ]);
 
         const results: { [key: string]: any } = {
@@ -101,8 +97,6 @@ export class AntModelManagerTest implements Test {
           get: getResult,
           mDelete: mDeleteResult,
           mGet: mGetResult,
-          mUpdate: mUpdateResult,
-          update: updateResult,
         };
 
         for (const methodToTest of methodsToTest) {
@@ -155,7 +149,7 @@ export class AntModelManagerTest implements Test {
             Promise.resolve(
               _.map(
                 iterableFilter(
-                  antModelManager.secondaryModelManager.store.values(),
+                  antModelManager.secondaryManager.store.values(),
                   (entity) => params.field === entity.field,
                 ),
                 (entity) => entity.id,
@@ -190,7 +184,7 @@ export class AntModelManagerTest implements Test {
           isMultiple: false,
           query: (params: any): Promise<number> => {
             const entity = iterableFind(
-              antModelManager.secondaryModelManager.store.values(),
+              antModelManager.secondaryManager.store.values(),
               (entity) => params.field === entity.field,
             );
             return Promise.resolve(entity ? entity[model.id] : null);
@@ -225,7 +219,7 @@ export class AntModelManagerTest implements Test {
           isMultiple: false,
           query: (params: any): Promise<number> => {
             const entity = iterableFind(
-              antModelManager.secondaryModelManager.store.values(),
+              antModelManager.secondaryManager.store.values(),
               (entity) => params.field === entity.field,
             );
             return Promise.resolve(entity ? entity[model.id] : null);
@@ -271,7 +265,7 @@ export class AntModelManagerTest implements Test {
       async (done) => {
         const model = modelGenerator(prefix);
         const antModelManager = new MinimalAntModelManager(model);
-        expect(() => antModelManager.modelManager).toThrowError();
+        expect(() => antModelManager.scheduledManager).toThrowError();
         done();
       },
       MAX_SAFE_TIMEOUT,

--- a/src/test/api/ant-model-manager-test.ts
+++ b/src/test/api/ant-model-manager-test.ts
@@ -152,9 +152,15 @@ export class AntModelManagerTest implements Test {
           query: (params: any): Promise<number[]> =>
             Promise.resolve(
               _.map(
-                (antModelManager.secondaryModelManager.store as Array<{ id: number; field: string }>).filter(
-                  (entity) => params.field === entity.field,
-                ),
+                ((): Entity[] => {
+                  const entitiesByField = new Array();
+                  for (const entity of antModelManager.secondaryModelManager.store.values()) {
+                    if (params.field === entity.field) {
+                      entitiesByField.push(entity);
+                    }
+                  }
+                  return entitiesByField;
+                })(),
                 (entity) => entity.id,
               ),
             ),
@@ -187,10 +193,13 @@ export class AntModelManagerTest implements Test {
           isMultiple: false,
           query: (params: any): Promise<number> =>
             new Promise<number>((resolve) => {
-              const entity = (antModelManager.secondaryModelManager.store as Array<{ id: number; field: string }>).find(
-                (entity) => params.field === entity.field,
-              );
-              resolve(entity ? entity.id : null);
+              for (const entity of antModelManager.secondaryModelManager.store.values()) {
+                if (params.field === entity.field) {
+                  resolve(entity[model.id]);
+                  return;
+                }
+              }
+              resolve(null);
             }),
           queryKeyGen: (params: any): string => prefix + 'query/' + params.field,
           reverseHashKey: prefix + 'query/reverse',
@@ -222,10 +231,13 @@ export class AntModelManagerTest implements Test {
           isMultiple: false,
           query: (params: any): Promise<number> =>
             new Promise<number>((resolve) => {
-              const entity = (antModelManager.secondaryModelManager.store as Array<{ id: number; field: string }>).find(
-                (entity) => params.field === entity.field,
-              );
-              resolve(entity ? entity.id : null);
+              for (const entity of antModelManager.secondaryModelManager.store.values()) {
+                if (params.field === entity.field) {
+                  resolve(entity[model.id]);
+                  return;
+                }
+              }
+              resolve(null);
             }),
           queryKeyGen: (params: any): string => prefix + 'query/' + params.field,
           reverseHashKey: prefix + 'query/reverse',

--- a/src/test/api/ant-model-manager-test.ts
+++ b/src/test/api/ant-model-manager-test.ts
@@ -78,12 +78,7 @@ export class AntModelManagerTest implements Test {
         });
         const modelManager = antModelManager.scheduledManager;
 
-        const methodsToTest: Array<keyof SchedulerModelManager<any, Model<any>>> = [
-          'delete',
-          'get',
-          'mDelete',
-          'mGet',
-        ];
+        const methodsToTest: Array<keyof SchedulerModelManager<any, Model<any>>> = ['delete', 'get', 'mDelete', 'mGet'];
 
         for (const methodToTest of methodsToTest) {
           spyOn(modelManager, methodToTest as any).and.returnValue(methodToTest as any);

--- a/src/test/api/ant-model-manager-test.ts
+++ b/src/test/api/ant-model-manager-test.ts
@@ -6,6 +6,8 @@ import { MinimalAntModelManager } from './minimal-ant-model-manager';
 import { PrimaryModelManager } from '../../persistence/primary/primary-model-manager';
 import { RedisWrapper } from '../primary/redis-wrapper';
 import { Test } from '../../testapi/api/test';
+import { iterableFilter } from '../util/iterable-filter';
+import { iterableFind } from '../util/iterable-find';
 
 const MAX_SAFE_TIMEOUT = Math.pow(2, 31) - 1;
 
@@ -152,15 +154,10 @@ export class AntModelManagerTest implements Test {
           query: (params: any): Promise<number[]> =>
             Promise.resolve(
               _.map(
-                ((): Entity[] => {
-                  const entitiesByField = new Array();
-                  for (const entity of antModelManager.secondaryModelManager.store.values()) {
-                    if (params.field === entity.field) {
-                      entitiesByField.push(entity);
-                    }
-                  }
-                  return entitiesByField;
-                })(),
+                iterableFilter(
+                  antModelManager.secondaryModelManager.store.values(),
+                  (entity) => params.field === entity.field,
+                ),
                 (entity) => entity.id,
               ),
             ),
@@ -191,16 +188,13 @@ export class AntModelManagerTest implements Test {
 
         const queryConfig = {
           isMultiple: false,
-          query: (params: any): Promise<number> =>
-            new Promise<number>((resolve) => {
-              for (const entity of antModelManager.secondaryModelManager.store.values()) {
-                if (params.field === entity.field) {
-                  resolve(entity[model.id]);
-                  return;
-                }
-              }
-              resolve(null);
-            }),
+          query: (params: any): Promise<number> => {
+            const entity = iterableFind(
+              antModelManager.secondaryModelManager.store.values(),
+              (entity) => params.field === entity.field,
+            );
+            return Promise.resolve(entity ? entity[model.id] : null);
+          },
           queryKeyGen: (params: any): string => prefix + 'query/' + params.field,
           reverseHashKey: prefix + 'query/reverse',
         };
@@ -229,16 +223,13 @@ export class AntModelManagerTest implements Test {
 
         const queryConfig = {
           isMultiple: false,
-          query: (params: any): Promise<number> =>
-            new Promise<number>((resolve) => {
-              for (const entity of antModelManager.secondaryModelManager.store.values()) {
-                if (params.field === entity.field) {
-                  resolve(entity[model.id]);
-                  return;
-                }
-              }
-              resolve(null);
-            }),
+          query: (params: any): Promise<number> => {
+            const entity = iterableFind(
+              antModelManager.secondaryModelManager.store.values(),
+              (entity) => params.field === entity.field,
+            );
+            return Promise.resolve(entity ? entity[model.id] : null);
+          },
           queryKeyGen: (params: any): string => prefix + 'query/' + params.field,
           reverseHashKey: prefix + 'query/reverse',
         };

--- a/src/test/api/ant-model-manager-test.ts
+++ b/src/test/api/ant-model-manager-test.ts
@@ -3,8 +3,9 @@ import { AntModel } from '../../model/ant-model';
 import { AntQueryManager } from '../../api/query/ant-query-manager';
 import { Entity } from '../../model/entity';
 import { MinimalAntModelManager } from './minimal-ant-model-manager';
-import { PrimaryModelManager } from '../../persistence/primary/primary-model-manager';
+import { Model } from '../../model/model';
 import { RedisWrapper } from '../primary/redis-wrapper';
+import { SchedulerModelManager } from '../../persistence/scheduler/scheduler-model-manager';
 import { Test } from '../../testapi/api/test';
 import { iterableFilter } from '../util/iterable-filter';
 import { iterableFind } from '../util/iterable-find';
@@ -75,9 +76,14 @@ export class AntModelManagerTest implements Test {
         antModelManager.config({
           redis: this._redis.redis,
         });
-        const modelManager = antModelManager.primaryManager;
+        const modelManager = antModelManager.scheduledManager;
 
-        const methodsToTest = ['delete', 'get', 'mDelete', 'mGet'] as Array<keyof PrimaryModelManager<any>>;
+        const methodsToTest: Array<keyof SchedulerModelManager<any, Model<any>>> = [
+          'delete',
+          'get',
+          'mDelete',
+          'mGet',
+        ];
 
         for (const methodToTest of methodsToTest) {
           spyOn(modelManager, methodToTest as any).and.returnValue(methodToTest as any);

--- a/src/test/api/minimal-ant-model-manager.ts
+++ b/src/test/api/minimal-ant-model-manager.ts
@@ -1,26 +1,34 @@
 import { AntJsModelManagerGenerator } from '../../testapi/api/generator/antjs-model-manager-generator';
 import { AntModelManager } from '../../api/ant-model-manager';
+import { AntScheduleModelManager } from '../../persistence/scheduler/ant-scheduler-model-manager';
 import { ApiModelConfig } from '../../api/config/api-model-config';
 import { Entity } from '../../model/entity';
 import { Model } from '../../model/model';
 import { PrimaryModelManager } from '../../persistence/primary/primary-model-manager';
 import { RedisWrapper } from '../primary/redis-wrapper';
+import { SchedulerModelManager } from '../../persistence/scheduler/scheduler-model-manager';
 import { SecondaryEntityManagerMock } from '../../testapi/api/secondary/secondary-entity-manager-mock';
 
 export class MinimalAntModelManager<TEntity extends Entity> extends AntModelManager<
   TEntity,
   ApiModelConfig,
   Model<TEntity>,
-  PrimaryModelManager<TEntity>
+  SchedulerModelManager<TEntity, Model<TEntity>>
 > {
   /**
    * Model manager generator.
    */
   protected _modelManagerGenerator: AntJsModelManagerGenerator;
+
   /**
-   * Secondary entity manager.
+   * Primary manager.
    */
-  protected _secondaryEntityManager: SecondaryEntityManagerMock<TEntity>;
+  protected _primaryManager: PrimaryModelManager<TEntity>;
+
+  /**
+   * Secondary manager.
+   */
+  protected _secondaryManager: SecondaryEntityManagerMock<TEntity>;
 
   /**
    * Generates a new MinimalAntModelManager.
@@ -29,37 +37,60 @@ export class MinimalAntModelManager<TEntity extends Entity> extends AntModelMana
    */
   public constructor(model: Model<TEntity>) {
     super(model);
-    this._modelManagerGenerator = new AntJsModelManagerGenerator(new RedisWrapper().redis);
-    this._secondaryEntityManager = new SecondaryEntityManagerMock<TEntity>(model);
+    const redisMiddleware = new RedisWrapper().redis;
+    this._modelManagerGenerator = new AntJsModelManagerGenerator(redisMiddleware);
+    this._secondaryManager = this._generateSecondaryManager(model);
+    this._primaryManager = this._generatePrimaryManager(model, { redis: redisMiddleware }, this._secondaryManager);
   }
 
   /**
    * Model manager.
    * @returns Model manager.
    */
-  public get modelManager(): PrimaryModelManager<TEntity> {
-    return super.modelManager;
+  public get primaryManager(): PrimaryModelManager<TEntity> {
+    return this._primaryManager;
+  }
+
+  public get scheduledManager(): SchedulerModelManager<TEntity, Model<TEntity>> {
+    return super.scheduledManager;
   }
   /**
    * Secondary model manager.
    * @returns secondary model manager.
    */
-  public get secondaryModelManager(): SecondaryEntityManagerMock<TEntity> {
-    return this._secondaryEntityManager;
+  public get secondaryManager(): SecondaryEntityManagerMock<TEntity> {
+    return this._secondaryManager;
   }
 
   /**
-   * Generates a model manager.
-   * @param model Model to manage.
-   * @returns Model manager generated.
+   * @inheritdoc
    */
-  protected _generateModelManager(model: Model<TEntity>): PrimaryModelManager<TEntity> {
+  protected _generatePrimaryManager(
+    model: Model<TEntity>,
+    config: ApiModelConfig,
+    secondaryManager: SecondaryEntityManagerMock<TEntity>,
+  ): PrimaryModelManager<TEntity> {
     const [modelManager] = this._modelManagerGenerator.generateModelManager({
       model,
+      redisOptions: { redis: config.redis },
       secondaryOptions: {
-        manager: this._secondaryEntityManager,
+        manager: secondaryManager,
       },
     });
     return modelManager as PrimaryModelManager<TEntity>;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected _generateScheduledManager(model: Model<TEntity>): SchedulerModelManager<TEntity, Model<TEntity>> {
+    return new AntScheduleModelManager(model, this._primaryManager, this._secondaryManager);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected _generateSecondaryManager(model: Model<TEntity>): SecondaryEntityManagerMock<TEntity> {
+    return new SecondaryEntityManagerMock<TEntity>(model);
   }
 }

--- a/src/test/api/query/ant-query-manager-test.ts
+++ b/src/test/api/query/ant-query-manager-test.ts
@@ -1,13 +1,10 @@
 import { AntModel } from '../../../model/ant-model';
 import { AntPrimaryModelManager } from '../../../persistence/primary/ant-primary-model-manager';
-import { AntScheduleModelManager } from '../../../persistence/scheduler/ant-scheduler-model-manager';
 import { ApiQueryManager } from '../../../api/query/api-query-manager';
 import { Entity } from '../../../model/entity';
 import { MinimalAntQueryManager } from './minimal-ant-query-manager';
 import { Model } from '../../../model/model';
-import { PrimaryModelManager } from '../../../persistence/primary/primary-model-manager';
 import { RedisWrapper } from '../../primary/redis-wrapper';
-import { SecondaryEntityManager } from '../../../persistence/secondary/secondary-entity-manager';
 import { SingleResultQueryByFieldManager } from '../../primary/query/single-result-query-by-field-manager';
 import { Test } from '../../../testapi/api/test';
 
@@ -66,15 +63,10 @@ export class AntQueryManagerTest implements Test {
       async (done) => {
         const model: Model<EntityTest> = modelGenerator(prefix);
         const primaryManager = new AntPrimaryModelManager(model, this._redis.redis, true);
-        const schedulerManager = new AntScheduleModelManager<
-          EntityTest,
-          Model<EntityTest>,
-          PrimaryModelManager<EntityTest>,
-          SecondaryEntityManager<EntityTest>
-        >(model, primaryManager, null);
         const queryManager = new SingleResultQueryByFieldManager<EntityTest>(
+          model,
+          primaryManager,
           async () => null,
-          schedulerManager,
           this._redis.redis,
           prefix + 'reverse/',
           'id',

--- a/src/test/api/query/ant-query-manager-test.ts
+++ b/src/test/api/query/ant-query-manager-test.ts
@@ -1,9 +1,11 @@
 import { AntModel } from '../../../model/ant-model';
-import { AntPrimaryEntityManager } from '../../../persistence/primary/ant-primary-entity-manager';
+import { AntPrimaryModelManager } from '../../../persistence/primary/ant-primary-model-manager';
+import { AntScheduleModelManager } from '../../../persistence/scheduler/ant-scheduler-model-manager';
 import { ApiQueryManager } from '../../../api/query/api-query-manager';
 import { Entity } from '../../../model/entity';
 import { MinimalAntQueryManager } from './minimal-ant-query-manager';
 import { Model } from '../../../model/model';
+import { PrimaryModelManager } from '../../../persistence/primary/primary-model-manager';
 import { RedisWrapper } from '../../primary/redis-wrapper';
 import { SecondaryEntityManager } from '../../../persistence/secondary/secondary-entity-manager';
 import { SingleResultQueryByFieldManager } from '../../primary/query/single-result-query-by-field-manager';
@@ -63,14 +65,16 @@ export class AntQueryManagerTest implements Test {
       itsName,
       async (done) => {
         const model: Model<EntityTest> = modelGenerator(prefix);
-        const primaryEntityManager = new AntPrimaryEntityManager<EntityTest, SecondaryEntityManager<EntityTest>>(
-          model,
-          this._redis.redis,
-          null,
-        );
+        const primaryManager = new AntPrimaryModelManager(model, this._redis.redis, true);
+        const schedulerManager = new AntScheduleModelManager<
+          EntityTest,
+          Model<EntityTest>,
+          PrimaryModelManager<EntityTest>,
+          SecondaryEntityManager<EntityTest>
+        >(model, primaryManager, null);
         const queryManager = new SingleResultQueryByFieldManager<EntityTest>(
           async () => null,
-          primaryEntityManager,
+          schedulerManager,
           this._redis.redis,
           prefix + 'reverse/',
           'id',

--- a/src/test/primary/lua-key-generator-test.ts
+++ b/src/test/primary/lua-key-generator-test.ts
@@ -1,0 +1,97 @@
+import { AntModel } from '../../model/ant-model';
+import { AntPrimaryEntityManager } from '../../persistence/primary/ant-primary-entity-manager';
+import { Entity } from '../../model/entity';
+import { Model } from '../../model/model';
+import { PrimaryEntityManager } from '../../persistence/primary/primary-entity-manager';
+import { RedisWrapper } from './redis-wrapper';
+import { SecondaryEntityManager } from '../../persistence/secondary/secondary-entity-manager';
+import { SecondaryEntityManagerMock } from '../../testapi/api/secondary/secondary-entity-manager-mock';
+import { Test } from '../../testapi/api/test';
+import { luaKeyGenerator } from '../../persistence/primary/lua-key-generator';
+
+const MAX_SAFE_TIMEOUT = Math.pow(2, 31) - 1;
+
+type EntityTest = Entity & {
+  id: number;
+  field: string;
+};
+
+export class LuaKeyGeneratorTest implements Test {
+  /**
+   * Before all task performed promise.
+   */
+  protected _beforeAllPromise: Promise<any>;
+  /**
+   * Declare name for the test
+   */
+  protected _declareName: string;
+  /**
+   * Redis Wrapper
+   */
+  protected _redis: RedisWrapper;
+
+  public constructor(beforeAllPromise: Promise<any>) {
+    this._beforeAllPromise = beforeAllPromise;
+    this._declareName = LuaKeyGeneratorTest.name;
+    this._redis = new RedisWrapper();
+  }
+
+  public performTests(): void {
+    describe(this._declareName, () => {
+      this._itMustGenerateALuaCodeByAnAlias();
+    });
+  }
+
+  /**
+   * Generates instances needed in almost every test.
+   * @param prefix prefix to generate redis keys.
+   * @param entities Entities to be stored in the secondary entity manager.
+   * @param useNegativeCache True to use negative entitty caching.
+   * @returns model, primary entity manager and secondary entity manager instanes.
+   */
+  private _helperGenerateBaseInstances(
+    prefix: string,
+    entities: EntityTest[],
+    useNegativeCache = true,
+  ): [Model<EntityTest>, PrimaryEntityManager<EntityTest>, SecondaryEntityManagerMock<EntityTest>] {
+    const model = new AntModel<EntityTest>('id', { prefix });
+    const secondaryEntityManager = new SecondaryEntityManagerMock<EntityTest>(model, entities);
+    const primaryEntityManager = new AntPrimaryEntityManager<EntityTest, SecondaryEntityManager<EntityTest>>(
+      model,
+      this._redis.redis,
+      useNegativeCache,
+      secondaryEntityManager,
+    );
+    return [model, primaryEntityManager, secondaryEntityManager];
+  }
+
+  private _itMustGenerateALuaCodeByAnAlias(): void {
+    const itsName = 'must generate a lua code by an alias';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(
+      itsName,
+      async (done) => {
+        await this._beforeAllPromise;
+        const entity: EntityTest = { field: 'sample', id: 0 };
+        const [model, primaryEntityManager] = this._helperGenerateBaseInstances(prefix, [entity]);
+        await primaryEntityManager.get(entity[model.id]);
+        const luaKey = 'key';
+        const luaExpression = luaKeyGenerator({ prefix })(luaKey);
+        const valueFound = await this._redis.redis.eval(
+          `local ${luaKey} = ${entity.id}
+return redis.call('get', ${luaExpression})`,
+          0,
+        );
+        if (null == valueFound) {
+          fail();
+          done();
+          return;
+        }
+        const entityFound = model.primaryToEntity(JSON.parse(valueFound));
+        expect(entityFound).toEqual(entity);
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
+  }
+}

--- a/src/test/primary/model-manager-test.ts
+++ b/src/test/primary/model-manager-test.ts
@@ -2,7 +2,6 @@ import * as _ from 'lodash';
 import { AntJsModelManagerGenerator } from '../../testapi/api/generator/antjs-model-manager-generator';
 import { AntJsUpdateOptions } from '../../persistence/primary/options/antjs-update-options';
 import { AntModel } from '../../model/ant-model';
-import { AntScheduleModelManager } from '../../persistence/scheduler/ant-scheduler-model-manager';
 import { CacheMode } from '../../persistence/primary/options/cache-mode';
 import { Entity } from '../../model/entity';
 import { Model } from '../../model/model';
@@ -11,7 +10,6 @@ import { PrimaryEntityManager } from '../../persistence/primary/primary-entity-m
 import { PrimaryModelManager } from '../../persistence/primary/primary-model-manager';
 import { PrimaryQueryManager } from '../../persistence/primary/query/primary-query-manager';
 import { RedisWrapper } from './redis-wrapper';
-import { SecondaryEntityManager } from '../../persistence/secondary/secondary-entity-manager';
 import { SecondaryEntityManagerMock } from '../../testapi/api/secondary/secondary-entity-manager-mock';
 import { SingleResultPrimaryQueryManager } from '../../persistence/primary/query/single-result-primary-query-manager';
 import { SingleResultQueryByFieldManager } from './query/single-result-query-by-field-manager';
@@ -150,20 +148,11 @@ export class ModelManagerTest implements Test {
             manager: secondaryEntityManager,
           },
         });
-        const schedulerManager = new AntScheduleModelManager<
-          EntityTest,
-          Model<EntityTest>,
-          PrimaryModelManager<EntityTest>,
-          SecondaryEntityManager<EntityTest>
-        >(
-          model,
-          modelManager as PrimaryModelManager<EntityTest>,
-          secondaryEntityManager,
-        );
 
         const singleResultQueryManager = new SingleResultQueryByFieldManager<EntityTest>(
+          model,
+          modelManager as PrimaryModelManager<EntityTest>,
           entityByStrFieldParam(model, secondaryEntityManager),
-          schedulerManager,
           this._redis.redis,
           prefix + 'reverse/strField/',
           'strField',
@@ -694,17 +683,9 @@ export class ModelManagerTest implements Test {
             manager: secondaryEntityManager,
           },
         });
-        const schedulerManager = new AntScheduleModelManager<
-          EntityTest,
-          Model<EntityTest>,
-          PrimaryModelManager<EntityTest>,
-          SecondaryEntityManager<EntityTest>
-        >(
+        const query = new MultipleResultQueryByFieldManager(
           model,
           modelManager as PrimaryModelManager<EntityTest>,
-          secondaryEntityManager,
-        );
-        const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
             Promise.resolve(
               _.map(
@@ -712,7 +693,6 @@ export class ModelManagerTest implements Test {
                 (entity) => entity.id,
               ),
             ),
-          schedulerManager,
           this._redis.redis,
           prefix + 'reverse/',
           'strField',
@@ -767,17 +747,9 @@ export class ModelManagerTest implements Test {
             manager: secondaryEntityManager,
           },
         });
-        const schedulerManager = new AntScheduleModelManager<
-          EntityTest,
-          Model<EntityTest>,
-          PrimaryModelManager<EntityTest>,
-          SecondaryEntityManager<EntityTest>
-        >(
+        const query = new MultipleResultQueryByFieldManager(
           model,
           modelManager as PrimaryModelManager<EntityTest>,
-          secondaryEntityManager,
-        );
-        const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
             Promise.resolve(
               _.map(
@@ -785,7 +757,6 @@ export class ModelManagerTest implements Test {
                 (entity) => entity.id,
               ),
             ),
-          schedulerManager,
           this._redis.redis,
           prefix + 'reverse/',
           'strField',
@@ -845,17 +816,9 @@ export class ModelManagerTest implements Test {
             manager: secondaryEntityManager,
           },
         });
-        const schedulerManager = new AntScheduleModelManager<
-          EntityTest,
-          Model<EntityTest>,
-          PrimaryModelManager<EntityTest>,
-          SecondaryEntityManager<EntityTest>
-        >(
+        const query = new MultipleResultQueryByFieldManager(
           model,
           modelManager as PrimaryModelManager<EntityTest>,
-          secondaryEntityManager,
-        );
-        const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
             Promise.resolve(
               _.map(
@@ -863,7 +826,6 @@ export class ModelManagerTest implements Test {
                 (entity) => entity.id,
               ),
             ),
-          schedulerManager,
           this._redis.redis,
           prefix + 'reverse/',
           'strField',
@@ -939,17 +901,9 @@ export class ModelManagerTest implements Test {
             manager: secondaryEntityManager,
           },
         });
-        const schedulerManager = new AntScheduleModelManager<
-          EntityTest,
-          Model<EntityTest>,
-          PrimaryModelManager<EntityTest>,
-          SecondaryEntityManager<EntityTest>
-        >(
+        const query = new MultipleResultQueryByFieldManager(
           model,
           modelManager as PrimaryModelManager<EntityTest>,
-          secondaryEntityManager,
-        );
-        const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
             Promise.resolve(
               _.map(
@@ -957,7 +911,6 @@ export class ModelManagerTest implements Test {
                 (entity) => entity.id,
               ),
             ),
-          schedulerManager,
           this._redis.redis,
           prefix + 'reverse/',
           'strField',
@@ -1020,19 +973,10 @@ export class ModelManagerTest implements Test {
             manager: secondaryEntityManager,
           },
         });
-        const schedulerManager = new AntScheduleModelManager<
-          EntityTest,
-          Model<EntityTest>,
-          PrimaryModelManager<EntityTest>,
-          SecondaryEntityManager<EntityTest>
-        >(
+        const query = new SingleResultQueryByFieldManager(
           model,
           modelManager as PrimaryModelManager<EntityTest>,
-          secondaryEntityManager,
-        );
-        const query = new SingleResultQueryByFieldManager(
           entityByStrFieldParam(model, secondaryEntityManager),
-          schedulerManager,
           this._redis.redis,
           prefix + 'reverse/',
           'strField',
@@ -1081,19 +1025,10 @@ export class ModelManagerTest implements Test {
             manager: secondaryEntityManager,
           },
         });
-        const schedulerManager = new AntScheduleModelManager<
-          EntityTest,
-          Model<EntityTest>,
-          PrimaryModelManager<EntityTest>,
-          SecondaryEntityManager<EntityTest>
-        >(
+        const query = new SingleResultQueryByFieldManager(
           model,
           modelManager as PrimaryModelManager<EntityTest>,
-          secondaryEntityManager,
-        );
-        const query = new SingleResultQueryByFieldManager(
           entityByStrFieldParam(model, secondaryEntityManager),
-          schedulerManager,
           this._redis.redis,
           prefix + 'reverse/',
           'strField',
@@ -1147,19 +1082,10 @@ export class ModelManagerTest implements Test {
             manager: secondaryEntityManager,
           },
         });
-        const schedulerManager = new AntScheduleModelManager<
-          EntityTest,
-          Model<EntityTest>,
-          PrimaryModelManager<EntityTest>,
-          SecondaryEntityManager<EntityTest>
-        >(
+        const query = new SingleResultQueryByFieldManager(
           model,
           modelManager as PrimaryModelManager<EntityTest>,
-          secondaryEntityManager,
-        );
-        const query = new SingleResultQueryByFieldManager(
           entityByStrFieldParam(model, secondaryEntityManager),
-          schedulerManager,
           this._redis.redis,
           prefix + 'reverse/',
           'strField',
@@ -1219,19 +1145,10 @@ export class ModelManagerTest implements Test {
             manager: secondaryEntityManager,
           },
         });
-        const schedulerManager = new AntScheduleModelManager<
-          EntityTest,
-          Model<EntityTest>,
-          PrimaryModelManager<EntityTest>,
-          SecondaryEntityManager<EntityTest>
-        >(
+        const query = new SingleResultQueryByFieldManager(
           model,
           modelManager as PrimaryModelManager<EntityTest>,
-          secondaryEntityManager,
-        );
-        const query = new SingleResultQueryByFieldManager(
           entityByStrFieldParam(model, secondaryEntityManager),
-          schedulerManager,
           this._redis.redis,
           prefix + 'reverse/',
           'strField',

--- a/src/test/primary/model-manager-test.ts
+++ b/src/test/primary/model-manager-test.ts
@@ -143,10 +143,13 @@ export class ModelManagerTest implements Test {
         const singleResultQueryManager = new SingleResultQueryByFieldManager<EntityTest>(
           (params: any) =>
             new Promise((resolve) => {
-              const entity = secondaryEntityManager.store.find(
-                (value: EntityTest) => value.strField === params.strField,
-              );
-              resolve(entity ? entity[model.id] : null);
+              for (const entity of secondaryEntityManager.store.values()) {
+                if (params.strField === entity.strField) {
+                  resolve(entity[model.id]);
+                  return;
+                }
+              }
+              resolve(null);
             }),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -223,7 +226,6 @@ export class ModelManagerTest implements Test {
           },
         });
 
-        secondaryEntityManager.store.shift();
         await modelManager.delete(entity1.id);
 
         const [searchEntity1ByPrimaryEntityManager, searchEntity1ByQueryManager] = await this._helperSearchEntity(
@@ -289,7 +291,6 @@ export class ModelManagerTest implements Test {
           },
         });
 
-        secondaryEntityManager.store.shift();
         await modelManager.delete(entity1.id);
 
         const [searchEntity1ByPrimaryEntityManager, searchEntity1ByQueryManager] = await this._helperSearchEntity(
@@ -358,8 +359,6 @@ export class ModelManagerTest implements Test {
             manager: secondaryEntityManager,
           },
         });
-        secondaryEntityManager.store.shift();
-        secondaryEntityManager.store.shift();
         await modelManager.mDelete([entity1.id, entity2.id]);
 
         const [searchEntity1ByPrimaryEntityManager, searchEntity1ByQueryManager] = await this._helperSearchEntity(
@@ -438,8 +437,6 @@ export class ModelManagerTest implements Test {
             manager: secondaryEntityManager,
           },
         });
-        secondaryEntityManager.store.shift();
-        secondaryEntityManager.store.shift();
         await modelManager.mDelete([entity1.id, entity2.id]);
 
         const [searchEntity1ByPrimaryEntityManager, searchEntity1ByQueryManager] = await this._helperSearchEntity(
@@ -670,10 +667,13 @@ export class ModelManagerTest implements Test {
         const singleResultQueryManager = new SingleResultQueryByFieldManager<EntityTest>(
           (params: any) =>
             new Promise((resolve) => {
-              const entity = secondaryEntityManager.store.find(
-                (value: EntityTest) => value.strField === params.strField,
-              );
-              resolve(entity ? entity[model.id] : null);
+              for (const entity of secondaryEntityManager.store.values()) {
+                if (params.strField === entity.strField) {
+                  resolve(entity[model.id]);
+                  return;
+                }
+              }
+              resolve(null);
             }),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -729,7 +729,15 @@ export class ModelManagerTest implements Test {
         const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
             new Promise((resolve) => {
-              const entities = secondaryEntityManager.store.filter((entity) => params.strField === entity.strField);
+              const entities = ((): Entity[] => {
+                const entitiesByField = new Array();
+                for (const entity of secondaryEntityManager.store.values()) {
+                  if (params.strField === entity.strField) {
+                    entitiesByField.push(entity);
+                  }
+                }
+                return entitiesByField;
+              })();
               resolve(_.map(entities, (entity) => entity.id));
             }),
           modelManager as PrimaryModelManager<EntityTest>,
@@ -740,7 +748,6 @@ export class ModelManagerTest implements Test {
         );
         modelManager.addQuery(query);
         await query.mGet([entity1, entity2, entity3]);
-        secondaryEntityManager.store.shift();
         await modelManager.delete(entity1.id);
         expect(await modelManager.get(entity1.id)).toBeNull();
         expect(await modelManager.get(entity2.id)).toEqual(entity2);
@@ -790,7 +797,15 @@ export class ModelManagerTest implements Test {
         const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
             new Promise((resolve) => {
-              const entities = secondaryEntityManager.store.filter((entity) => params.strField === entity.strField);
+              const entities = ((): Entity[] => {
+                const entitiesByField = new Array();
+                for (const entity of secondaryEntityManager.store.values()) {
+                  if (params.strField === entity.strField) {
+                    entitiesByField.push(entity);
+                  }
+                }
+                return entitiesByField;
+              })();
               resolve(_.map(entities, (entity) => entity.id));
             }),
           modelManager as PrimaryModelManager<EntityTest>,
@@ -801,8 +816,6 @@ export class ModelManagerTest implements Test {
         );
         modelManager.addQuery(query);
         await query.mGet([entity1, entity2, entity3]);
-        secondaryEntityManager.store.pop();
-        secondaryEntityManager.store.shift();
         await modelManager.mDelete([entity1.id, entity3.id]);
         expect(await modelManager.get(entity1.id)).toBeNull();
         expect(await modelManager.get(entity2.id)).toEqual(entity2);
@@ -857,7 +870,15 @@ export class ModelManagerTest implements Test {
         const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
             new Promise((resolve) => {
-              const entities = secondaryEntityManager.store.filter((entity) => params.strField === entity.strField);
+              const entities = ((): Entity[] => {
+                const entitiesByField = new Array();
+                for (const entity of secondaryEntityManager.store.values()) {
+                  if (params.strField === entity.strField) {
+                    entitiesByField.push(entity);
+                  }
+                }
+                return entitiesByField;
+              })();
               resolve(_.map(entities, (entity) => entity.id));
             }),
           modelManager as PrimaryModelManager<EntityTest>,
@@ -868,7 +889,7 @@ export class ModelManagerTest implements Test {
         );
         modelManager.addQuery(query);
         await query.mGet([entity1, entity2, entity3]);
-        secondaryEntityManager.store[0] = entity1After;
+        secondaryEntityManager.store.set(entity1After[model.id], entity1After);
         await modelManager.update(entity1After);
         const [entity1SearchResult, entity2SearchResult, entity3SearchResult] = await modelManager.mGet([
           entity1After.id,
@@ -939,7 +960,15 @@ export class ModelManagerTest implements Test {
         const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
             new Promise((resolve) => {
-              const entities = secondaryEntityManager.store.filter((entity) => params.strField === entity.strField);
+              const entities = ((): Entity[] => {
+                const entitiesByField = new Array();
+                for (const entity of secondaryEntityManager.store.values()) {
+                  if (params.strField === entity.strField) {
+                    entitiesByField.push(entity);
+                  }
+                }
+                return entitiesByField;
+              })();
               resolve(_.map(entities, (entity) => entity.id));
             }),
           modelManager as PrimaryModelManager<EntityTest>,
@@ -950,8 +979,8 @@ export class ModelManagerTest implements Test {
         );
         modelManager.addQuery(query);
         await query.mGet([entity1, entity2, entity3]);
-        secondaryEntityManager.store[0] = entity1After;
-        secondaryEntityManager.store[2] = entity3After;
+        secondaryEntityManager.store.set(entity1After[model.id], entity1After);
+        secondaryEntityManager.store.set(entity3After[model.id], entity3After);
         await modelManager.mUpdate([entity1After, entity3After]);
         const [entity1SearchResult, entity2SearchResult, entity3SearchResult] = await modelManager.mGet([
           entity1After.id,
@@ -1008,8 +1037,13 @@ export class ModelManagerTest implements Test {
         const query = new SingleResultQueryByFieldManager(
           (params: any) =>
             new Promise((resolve) => {
-              const entity = secondaryEntityManager.store.find((entity) => params.strField === entity.strField);
-              resolve(entity ? entity.id : null);
+              for (const entity of secondaryEntityManager.store.values()) {
+                if (params.strField === entity.strField) {
+                  resolve(entity[model.id]);
+                  return;
+                }
+              }
+              resolve(null);
             }),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -1019,7 +1053,6 @@ export class ModelManagerTest implements Test {
         );
         modelManager.addQuery(query);
         await Promise.all([query.get(entity1), query.get(entity2)]);
-        secondaryEntityManager.store.shift();
         await modelManager.delete(entity1.id);
         expect(await modelManager.get(entity1.id)).toBeNull();
         expect(await modelManager.get(entity2.id)).toEqual(entity2);
@@ -1063,8 +1096,13 @@ export class ModelManagerTest implements Test {
         const query = new SingleResultQueryByFieldManager(
           (params: any) =>
             new Promise((resolve) => {
-              const entity = secondaryEntityManager.store.find((entity) => params.strField === entity.strField);
-              resolve(entity ? entity.id : null);
+              for (const entity of secondaryEntityManager.store.values()) {
+                if (params.strField === entity.strField) {
+                  resolve(entity[model.id]);
+                  return;
+                }
+              }
+              resolve(null);
             }),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -1074,7 +1112,6 @@ export class ModelManagerTest implements Test {
         );
         modelManager.addQuery(query);
         await Promise.all([query.get(entity1), query.get(entity2)]);
-        secondaryEntityManager.store.length = 0;
         await modelManager.mDelete([entity1.id, entity2.id]);
         expect(await modelManager.get(entity1.id)).toBeNull();
         expect(await modelManager.get(entity2.id)).toBeNull();
@@ -1123,8 +1160,13 @@ export class ModelManagerTest implements Test {
         const query = new SingleResultQueryByFieldManager(
           (params: any) =>
             new Promise((resolve) => {
-              const entity = secondaryEntityManager.store.find((entity) => params.strField === entity.strField);
-              resolve(entity ? entity.id : null);
+              for (const entity of secondaryEntityManager.store.values()) {
+                if (params.strField === entity.strField) {
+                  resolve(entity[model.id]);
+                  return;
+                }
+              }
+              resolve(null);
             }),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -1134,7 +1176,7 @@ export class ModelManagerTest implements Test {
         );
         modelManager.addQuery(query);
         await Promise.all([query.get(entity1), query.get(entity2)]);
-        secondaryEntityManager.store[0] = entity1After;
+        secondaryEntityManager.store.set(entity1After[model.id], entity1After);
         await modelManager.update(entity1After);
         expect(await modelManager.get(entity1After.id)).toEqual(entity1After);
         expect(await modelManager.get(entity2.id)).toEqual(entity2);
@@ -1189,8 +1231,13 @@ export class ModelManagerTest implements Test {
         const query = new SingleResultQueryByFieldManager(
           (params: any) =>
             new Promise((resolve) => {
-              const entity = secondaryEntityManager.store.find((entity) => params.strField === entity.strField);
-              resolve(entity ? entity.id : null);
+              for (const entity of secondaryEntityManager.store.values()) {
+                if (params.strField === entity.strField) {
+                  resolve(entity[model.id]);
+                  return;
+                }
+              }
+              resolve(null);
             }),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -1200,8 +1247,8 @@ export class ModelManagerTest implements Test {
         );
         modelManager.addQuery(query);
         await Promise.all([query.get(entity1), query.get(entity2)]);
-        secondaryEntityManager.store[0] = entity1After;
-        secondaryEntityManager.store[1] = entity2After;
+        secondaryEntityManager.store.set(entity1After[model.id], entity1After);
+        secondaryEntityManager.store.set(entity2After[model.id], entity2After);
         await modelManager.mUpdate([entity1After, entity2After]);
         expect(await modelManager.get(entity1After.id)).toEqual(entity1After);
         expect(await modelManager.get(entity2After.id)).toEqual(entity2After);

--- a/src/test/primary/model-manager-test.ts
+++ b/src/test/primary/model-manager-test.ts
@@ -31,10 +31,7 @@ const entityByStrFieldParam = <T extends number | string>(
   model: Model<Entity>,
   secondaryEntityManager: SecondaryEntityManagerMock<Entity>,
 ) => (params: any): Promise<T> => {
-  const entity = iterableFind(
-    secondaryEntityManager.store.values(),
-    (entity) => params.strField === entity.strField,
-  );
+  const entity = iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField);
   return Promise.resolve(entity ? entity[model.id] : null);
 };
 
@@ -727,7 +724,7 @@ export class ModelManagerTest implements Test {
               _.map(
                 iterableFilter(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField),
                 (entity) => entity.id,
-              )
+              ),
             ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -789,7 +786,7 @@ export class ModelManagerTest implements Test {
               _.map(
                 iterableFilter(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField),
                 (entity) => entity.id,
-              )
+              ),
             ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -856,7 +853,7 @@ export class ModelManagerTest implements Test {
               _.map(
                 iterableFilter(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField),
                 (entity) => entity.id,
-              )
+              ),
             ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
@@ -940,7 +937,7 @@ export class ModelManagerTest implements Test {
               _.map(
                 iterableFilter(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField),
                 (entity) => entity.id,
-              )
+              ),
             ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,

--- a/src/test/primary/model-manager-test.ts
+++ b/src/test/primary/model-manager-test.ts
@@ -14,6 +14,8 @@ import { SecondaryEntityManagerMock } from '../../testapi/api/secondary/secondar
 import { SingleResultPrimaryQueryManager } from '../../persistence/primary/query/single-result-primary-query-manager';
 import { SingleResultQueryByFieldManager } from './query/single-result-query-by-field-manager';
 import { Test } from '../../testapi/api/test';
+import { iterableFilter } from '../util/iterable-filter';
+import { iterableFind } from '../util/iterable-find';
 
 const MAX_SAFE_TIMEOUT = Math.pow(2, 31) - 1;
 
@@ -142,15 +144,9 @@ export class ModelManagerTest implements Test {
 
         const singleResultQueryManager = new SingleResultQueryByFieldManager<EntityTest>(
           (params: any) =>
-            new Promise((resolve) => {
-              for (const entity of secondaryEntityManager.store.values()) {
-                if (params.strField === entity.strField) {
-                  resolve(entity[model.id]);
-                  return;
-                }
-              }
-              resolve(null);
-            }),
+            Promise.resolve(
+              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
+            ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/strField/',
@@ -666,15 +662,9 @@ export class ModelManagerTest implements Test {
 
         const singleResultQueryManager = new SingleResultQueryByFieldManager<EntityTest>(
           (params: any) =>
-            new Promise((resolve) => {
-              for (const entity of secondaryEntityManager.store.values()) {
-                if (params.strField === entity.strField) {
-                  resolve(entity[model.id]);
-                  return;
-                }
-              }
-              resolve(null);
-            }),
+            Promise.resolve(
+              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
+            ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/strField/',
@@ -728,18 +718,12 @@ export class ModelManagerTest implements Test {
         });
         const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
-            new Promise((resolve) => {
-              const entities = ((): Entity[] => {
-                const entitiesByField = new Array();
-                for (const entity of secondaryEntityManager.store.values()) {
-                  if (params.strField === entity.strField) {
-                    entitiesByField.push(entity);
-                  }
-                }
-                return entitiesByField;
-              })();
-              resolve(_.map(entities, (entity) => entity.id));
-            }),
+            Promise.resolve(
+              _.map(
+                iterableFilter(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField),
+                (entity) => entity.id,
+              )
+            ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',
@@ -796,18 +780,12 @@ export class ModelManagerTest implements Test {
         });
         const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
-            new Promise((resolve) => {
-              const entities = ((): Entity[] => {
-                const entitiesByField = new Array();
-                for (const entity of secondaryEntityManager.store.values()) {
-                  if (params.strField === entity.strField) {
-                    entitiesByField.push(entity);
-                  }
-                }
-                return entitiesByField;
-              })();
-              resolve(_.map(entities, (entity) => entity.id));
-            }),
+            Promise.resolve(
+              _.map(
+                iterableFilter(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField),
+                (entity) => entity.id,
+              )
+            ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',
@@ -869,18 +847,12 @@ export class ModelManagerTest implements Test {
         });
         const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
-            new Promise((resolve) => {
-              const entities = ((): Entity[] => {
-                const entitiesByField = new Array();
-                for (const entity of secondaryEntityManager.store.values()) {
-                  if (params.strField === entity.strField) {
-                    entitiesByField.push(entity);
-                  }
-                }
-                return entitiesByField;
-              })();
-              resolve(_.map(entities, (entity) => entity.id));
-            }),
+            Promise.resolve(
+              _.map(
+                iterableFilter(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField),
+                (entity) => entity.id,
+              )
+            ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',
@@ -959,18 +931,12 @@ export class ModelManagerTest implements Test {
         });
         const query = new MultipleResultQueryByFieldManager(
           (params: any) =>
-            new Promise((resolve) => {
-              const entities = ((): Entity[] => {
-                const entitiesByField = new Array();
-                for (const entity of secondaryEntityManager.store.values()) {
-                  if (params.strField === entity.strField) {
-                    entitiesByField.push(entity);
-                  }
-                }
-                return entitiesByField;
-              })();
-              resolve(_.map(entities, (entity) => entity.id));
-            }),
+            Promise.resolve(
+              _.map(
+                iterableFilter(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField),
+                (entity) => entity.id,
+              )
+            ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',
@@ -1036,15 +1002,9 @@ export class ModelManagerTest implements Test {
         });
         const query = new SingleResultQueryByFieldManager(
           (params: any) =>
-            new Promise((resolve) => {
-              for (const entity of secondaryEntityManager.store.values()) {
-                if (params.strField === entity.strField) {
-                  resolve(entity[model.id]);
-                  return;
-                }
-              }
-              resolve(null);
-            }),
+            Promise.resolve(
+              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
+            ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',
@@ -1095,15 +1055,9 @@ export class ModelManagerTest implements Test {
         });
         const query = new SingleResultQueryByFieldManager(
           (params: any) =>
-            new Promise((resolve) => {
-              for (const entity of secondaryEntityManager.store.values()) {
-                if (params.strField === entity.strField) {
-                  resolve(entity[model.id]);
-                  return;
-                }
-              }
-              resolve(null);
-            }),
+            Promise.resolve(
+              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
+            ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',
@@ -1159,15 +1113,9 @@ export class ModelManagerTest implements Test {
         });
         const query = new SingleResultQueryByFieldManager(
           (params: any) =>
-            new Promise((resolve) => {
-              for (const entity of secondaryEntityManager.store.values()) {
-                if (params.strField === entity.strField) {
-                  resolve(entity[model.id]);
-                  return;
-                }
-              }
-              resolve(null);
-            }),
+            Promise.resolve(
+              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
+            ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',
@@ -1230,15 +1178,9 @@ export class ModelManagerTest implements Test {
         });
         const query = new SingleResultQueryByFieldManager(
           (params: any) =>
-            new Promise((resolve) => {
-              for (const entity of secondaryEntityManager.store.values()) {
-                if (params.strField === entity.strField) {
-                  resolve(entity[model.id]);
-                  return;
-                }
-              }
-              resolve(null);
-            }),
+            Promise.resolve(
+              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
+            ),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',

--- a/src/test/primary/model-manager-test.ts
+++ b/src/test/primary/model-manager-test.ts
@@ -27,6 +27,17 @@ interface EntityTest extends Entity {
 const modelTestProperties = ['id', 'numberField', 'strField'];
 const modelTestGenerator = (prefix: string): AntModel<EntityTest> => new AntModel<EntityTest>('id', { prefix });
 
+const entityByStrFieldParam = <T extends number | string>(
+  model: Model<Entity>,
+  secondaryEntityManager: SecondaryEntityManagerMock<Entity>,
+) => (params: any): Promise<T> => {
+  const entity = iterableFind(
+    secondaryEntityManager.store.values(),
+    (entity) => params.strField === entity.strField,
+  );
+  return Promise.resolve(entity ? entity[model.id] : null);
+};
+
 export class ModelManagerTest implements Test {
   /**
    * Before all task performed promise.
@@ -143,10 +154,7 @@ export class ModelManagerTest implements Test {
         });
 
         const singleResultQueryManager = new SingleResultQueryByFieldManager<EntityTest>(
-          (params: any) =>
-            Promise.resolve(
-              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
-            ),
+          entityByStrFieldParam(model, secondaryEntityManager),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/strField/',
@@ -661,10 +669,7 @@ export class ModelManagerTest implements Test {
         });
 
         const singleResultQueryManager = new SingleResultQueryByFieldManager<EntityTest>(
-          (params: any) =>
-            Promise.resolve(
-              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
-            ),
+          entityByStrFieldParam(model, secondaryEntityManager),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/strField/',
@@ -1001,10 +1006,7 @@ export class ModelManagerTest implements Test {
           },
         });
         const query = new SingleResultQueryByFieldManager(
-          (params: any) =>
-            Promise.resolve(
-              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
-            ),
+          entityByStrFieldParam(model, secondaryEntityManager),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',
@@ -1054,10 +1056,7 @@ export class ModelManagerTest implements Test {
           },
         });
         const query = new SingleResultQueryByFieldManager(
-          (params: any) =>
-            Promise.resolve(
-              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
-            ),
+          entityByStrFieldParam(model, secondaryEntityManager),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',
@@ -1112,10 +1111,7 @@ export class ModelManagerTest implements Test {
           },
         });
         const query = new SingleResultQueryByFieldManager(
-          (params: any) =>
-            Promise.resolve(
-              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
-            ),
+          entityByStrFieldParam(model, secondaryEntityManager),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',
@@ -1177,10 +1173,7 @@ export class ModelManagerTest implements Test {
           },
         });
         const query = new SingleResultQueryByFieldManager(
-          (params: any) =>
-            Promise.resolve(
-              iterableFind(secondaryEntityManager.store.values(), (entity) => params.strField === entity.strField)?.id,
-            ),
+          entityByStrFieldParam(model, secondaryEntityManager),
           modelManager as PrimaryModelManager<EntityTest>,
           this._redis.redis,
           prefix + 'reverse/',

--- a/src/test/primary/primary-entity-manager-test.ts
+++ b/src/test/primary/primary-entity-manager-test.ts
@@ -123,7 +123,7 @@ export class PrimaryEntityManagerTest implements Test {
         ]);
 
         await primaryEntityManager.get(entity1[model.id]);
-        secondaryEntityManager.store[0] = entity1Modified;
+        secondaryEntityManager.store.set(entity1Modified[model.id], entity1Modified);
 
         expect(
           await primaryEntityManager.get(
@@ -156,7 +156,7 @@ export class PrimaryEntityManagerTest implements Test {
           [entity1[model.id]],
           new AntJsSearchOptions(new AntJsDeleteOptions(), new AntJsUpdateOptions(CacheMode.NoCache)),
         );
-        secondaryEntityManager.store.pop();
+        secondaryEntityManager.store.clear();
 
         expect(await primaryEntityManager.get(entity1[model.id])).toBe(null);
         done();
@@ -183,7 +183,7 @@ export class PrimaryEntityManagerTest implements Test {
           entity1[model.id],
           new AntJsSearchOptions(new AntJsDeleteOptions(), new AntJsUpdateOptions(CacheMode.NoCache)),
         );
-        secondaryEntityManager.store.pop();
+        secondaryEntityManager.store.clear();
 
         expect(await primaryEntityManager.get(entity1[model.id])).toBe(null);
         done();

--- a/src/test/primary/primary-entity-manager-test.ts
+++ b/src/test/primary/primary-entity-manager-test.ts
@@ -53,7 +53,6 @@ export class PrimaryEntityManagerTest implements Test {
       this._itDoesNotCacheEntityIfNoCacheOptionIsProvided();
       this._itDoesNotSupportUndefinedCacheOptionAtCacheEntities();
       this._itDoesNotSupportUndefinedCacheOptionAtCacheEntity();
-      this._itGeneratesALuaKeyGeneratorUsingAPrefix();
       this._itInvokesEntityToPrimaryAtGet();
       this._itInvokesEntityToPrimaryAtMGet();
       this._itInvokesPrimaryToEntityAtGet();
@@ -255,36 +254,6 @@ export class PrimaryEntityManagerTest implements Test {
         } catch {
           done();
         }
-      },
-      MAX_SAFE_TIMEOUT,
-    );
-  }
-
-  private _itGeneratesALuaKeyGeneratorUsingAPrefix(): void {
-    const itsName = 'generatesALuaKeyGeneratorUsingAPrefix';
-    const prefix = this._declareName + '/' + itsName + '/';
-    it(
-      itsName,
-      async (done) => {
-        await this._beforeAllPromise;
-        const entity: EntityTest = { field: 'sample', id: 0 };
-        const [model, primaryEntityManager] = this._helperGenerateBaseInstances(prefix, [entity]);
-        await primaryEntityManager.get(entity[model.id]);
-        const luaKey = 'key';
-        const luaExpression = primaryEntityManager.getLuaKeyGeneratorFromId()(luaKey);
-        const valueFound = await this._redis.redis.eval(
-          `local ${luaKey} = ${entity.id}
-return redis.call('get', ${luaExpression})`,
-          0,
-        );
-        if (null == valueFound) {
-          fail();
-          done();
-          return;
-        }
-        const entityFound = model.primaryToEntity(JSON.parse(valueFound));
-        expect(entityFound).toEqual(entity);
-        done();
       },
       MAX_SAFE_TIMEOUT,
     );

--- a/src/test/primary/query/multiple-result-query-by-field-manager.ts
+++ b/src/test/primary/query/multiple-result-query-by-field-manager.ts
@@ -2,8 +2,8 @@ import { TMQuery, TQuery } from '../../../persistence/primary/query/query-types'
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
+import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
-import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 
 export class MultipleResultQueryByFieldManager<TEntity extends Entity> extends AntMultipleResultPrimaryQueryManager<
   TEntity
@@ -18,18 +18,12 @@ export class MultipleResultQueryByFieldManager<TEntity extends Entity> extends A
   protected _queryPrefix: string;
 
   /**
-   * Creates a query by field manager.
-   * @param query Query.
-   * @param manager Primary entity manager.
-   * @param redis Redis connection.
-   * @param reverseHashKey Reverse hash key.
-   * @param field Query field.
-   * @param queryPrefix Query prefix.
-   * @param mQuery Multiple result query.
+   * @inheritdoc
    */
   public constructor(
+    model: Model<TEntity>,
+    manager: PrimaryEntityManager<TEntity>,
     query: TQuery<number[] | string[]>,
-    manager: SchedulerModelManager<TEntity, Model<TEntity>>,
     redis: RedisMiddleware,
     reverseHashKey: string,
     field: string,
@@ -44,7 +38,7 @@ export class MultipleResultQueryByFieldManager<TEntity extends Entity> extends A
     const key = (param: any): string => {
       return this._queryPrefix + param[this._field];
     };
-    super(query, manager, redis, reverseHashKey, key, key, mQuery);
+    super(model, manager, query, redis, reverseHashKey, key, key, mQuery);
     this._field = field;
     this._queryPrefix = queryPrefix;
   }

--- a/src/test/primary/query/multiple-result-query-by-field-manager.ts
+++ b/src/test/primary/query/multiple-result-query-by-field-manager.ts
@@ -1,8 +1,9 @@
 import { TMQuery, TQuery } from '../../../persistence/primary/query/query-types';
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
-import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
+import { Model } from '../../../model/model';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
+import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 
 export class MultipleResultQueryByFieldManager<TEntity extends Entity> extends AntMultipleResultPrimaryQueryManager<
   TEntity
@@ -19,7 +20,7 @@ export class MultipleResultQueryByFieldManager<TEntity extends Entity> extends A
   /**
    * Creates a query by field manager.
    * @param query Query.
-   * @param primaryEntityManager Primary entity manager.
+   * @param manager Primary entity manager.
    * @param redis Redis connection.
    * @param reverseHashKey Reverse hash key.
    * @param field Query field.
@@ -28,7 +29,7 @@ export class MultipleResultQueryByFieldManager<TEntity extends Entity> extends A
    */
   public constructor(
     query: TQuery<number[] | string[]>,
-    primaryEntityManager: PrimaryEntityManager<TEntity>,
+    manager: SchedulerModelManager<TEntity, Model<TEntity>>,
     redis: RedisMiddleware,
     reverseHashKey: string,
     field: string,
@@ -43,7 +44,7 @@ export class MultipleResultQueryByFieldManager<TEntity extends Entity> extends A
     const key = (param: any): string => {
       return this._queryPrefix + param[this._field];
     };
-    super(query, primaryEntityManager, redis, reverseHashKey, key, key, mQuery);
+    super(query, manager, redis, reverseHashKey, key, key, mQuery);
     this._field = field;
     this._queryPrefix = queryPrefix;
   }

--- a/src/test/primary/query/multiple-result-query-manager-test.ts
+++ b/src/test/primary/query/multiple-result-query-manager-test.ts
@@ -59,11 +59,7 @@ export class MultipleResultQueryManagerTest implements Test {
   private _helperGenerateBaseInstances(
     prefix: string,
     entities: NamedEntity[],
-  ): [
-    Model<NamedEntity>,
-    PrimaryModelManager<NamedEntity>,
-    SecondaryEntityManagerMock<NamedEntity>,
-  ] {
+  ): [Model<NamedEntity>, PrimaryModelManager<NamedEntity>, SecondaryEntityManagerMock<NamedEntity>] {
     const model = new AntModel<NamedEntity>('id', { prefix });
     const secondaryEntityManager = new SecondaryEntityManagerMock<NamedEntity>(model, entities);
     const primaryManager = new AntPrimaryModelManager(model, this._redis.redis, true, secondaryEntityManager);

--- a/src/test/primary/query/multiple-result-query-manager-test.ts
+++ b/src/test/primary/query/multiple-result-query-manager-test.ts
@@ -259,6 +259,7 @@ export class MultipleResultQueryManagerTest implements Test {
         );
         await queryManager.get(entity1);
         await modelManager.delete(entity1.id);
+        secondaryEntityManager.store.set(entity1[model.id], entity1);
         const entityFound = await queryManager.get(entity1);
         expect(entityFound).toEqual([entity1]);
         done();

--- a/src/test/primary/query/names-starting-by-letter-alternative.ts
+++ b/src/test/primary/query/names-starting-by-letter-alternative.ts
@@ -43,7 +43,15 @@ export class NamesStartingByLetterAlternative extends AntMultipleResultPrimaryQu
       (params: any) =>
         Promise.resolve(
           _.map(
-            secondaryModelManagerMock.store.filter((entity) => entity.name.startsWith(params.name[0])),
+            ((): Entity[] => {
+              const filteredEntities = new Array();
+              for (const entity of secondaryModelManagerMock.store.values()) {
+                if (entity.name.startsWith(params.name[0])) {
+                  filteredEntities.push(entity);
+                }
+              }
+              return filteredEntities;
+            })(),
             (entity) => entity.id,
           ),
         ),

--- a/src/test/primary/query/names-starting-by-letter-alternative.ts
+++ b/src/test/primary/query/names-starting-by-letter-alternative.ts
@@ -4,6 +4,7 @@ import { Entity } from '../../../model/entity';
 import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
 import { SecondaryEntityManagerMock } from '../../../testapi/api/secondary/secondary-entity-manager-mock';
+import { iterableFilter } from '../../util/iterable-filter';
 
 export type NamedEntityAlternative = { id: string; name: string } & Entity;
 
@@ -43,15 +44,10 @@ export class NamesStartingByLetterAlternative extends AntMultipleResultPrimaryQu
       (params: any) =>
         Promise.resolve(
           _.map(
-            ((): Entity[] => {
-              const filteredEntities = new Array();
-              for (const entity of secondaryModelManagerMock.store.values()) {
-                if (entity.name.startsWith(params.name[0])) {
-                  filteredEntities.push(entity);
-                }
-              }
-              return filteredEntities;
-            })(),
+            iterableFilter(
+              secondaryModelManagerMock.store.values(),
+              (entity) => entity.name.startsWith(params.name[0]),
+            ),
             (entity) => entity.id,
           ),
         ),

--- a/src/test/primary/query/names-starting-by-letter-alternative.ts
+++ b/src/test/primary/query/names-starting-by-letter-alternative.ts
@@ -2,8 +2,8 @@ import * as _ from 'lodash';
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
+import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
-import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 import { SecondaryEntityManagerMock } from '../../../testapi/api/secondary/secondary-entity-manager-mock';
 import { iterableFilter } from '../../util/iterable-filter';
 
@@ -16,14 +16,11 @@ export class NamesStartingByLetterAlternative extends AntMultipleResultPrimaryQu
   protected _prefix: string;
 
   /**
-   * Creates a new NamesStartingByLetter.
-   * @param manager Primary entity manager.
-   * @param redis Redis connection.
-   * @param reverseHashKey Reverse hash key.
-   * @param prefix Query prefix.
+   * @inheritdoc
    */
   public constructor(
-    manager: SchedulerModelManager<NamedEntityAlternative, Model<NamedEntityAlternative>>,
+    model: Model<NamedEntityAlternative>,
+    manager: PrimaryEntityManager<NamedEntityAlternative>,
     secondaryModelManagerMock: SecondaryEntityManagerMock<NamedEntityAlternative>,
     redis: RedisMiddleware,
     reverseHashKey: string,
@@ -42,6 +39,8 @@ export class NamesStartingByLetterAlternative extends AntMultipleResultPrimaryQu
       }
     };
     super(
+      model,
+      manager,
       (params: any) =>
         Promise.resolve(
           _.map(
@@ -51,7 +50,6 @@ export class NamesStartingByLetterAlternative extends AntMultipleResultPrimaryQu
             (entity) => entity.id,
           ),
         ),
-      manager,
       redis,
       reverseHashKey,
       key,

--- a/src/test/primary/query/names-starting-by-letter-alternative.ts
+++ b/src/test/primary/query/names-starting-by-letter-alternative.ts
@@ -1,8 +1,9 @@
 import * as _ from 'lodash';
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
-import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
+import { Model } from '../../../model/model';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
+import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 import { SecondaryEntityManagerMock } from '../../../testapi/api/secondary/secondary-entity-manager-mock';
 import { iterableFilter } from '../../util/iterable-filter';
 
@@ -16,13 +17,13 @@ export class NamesStartingByLetterAlternative extends AntMultipleResultPrimaryQu
 
   /**
    * Creates a new NamesStartingByLetter.
-   * @param primaryEntityManager Primary entity manager.
+   * @param manager Primary entity manager.
    * @param redis Redis connection.
    * @param reverseHashKey Reverse hash key.
    * @param prefix Query prefix.
    */
   public constructor(
-    primaryEntityManager: PrimaryEntityManager<NamedEntityAlternative>,
+    manager: SchedulerModelManager<NamedEntityAlternative, Model<NamedEntityAlternative>>,
     secondaryModelManagerMock: SecondaryEntityManagerMock<NamedEntityAlternative>,
     redis: RedisMiddleware,
     reverseHashKey: string,
@@ -50,7 +51,7 @@ export class NamesStartingByLetterAlternative extends AntMultipleResultPrimaryQu
             (entity) => entity.id,
           ),
         ),
-      primaryEntityManager,
+      manager,
       redis,
       reverseHashKey,
       key,

--- a/src/test/primary/query/names-starting-by-letter-alternative.ts
+++ b/src/test/primary/query/names-starting-by-letter-alternative.ts
@@ -44,9 +44,8 @@ export class NamesStartingByLetterAlternative extends AntMultipleResultPrimaryQu
       (params: any) =>
         Promise.resolve(
           _.map(
-            iterableFilter(
-              secondaryModelManagerMock.store.values(),
-              (entity) => entity.name.startsWith(params.name[0]),
+            iterableFilter(secondaryModelManagerMock.store.values(), (entity) =>
+              entity.name.startsWith(params.name[0]),
             ),
             (entity) => entity.id,
           ),

--- a/src/test/primary/query/names-starting-by-letter.ts
+++ b/src/test/primary/query/names-starting-by-letter.ts
@@ -44,9 +44,8 @@ export class NamesStartingByLetter extends AntMultipleResultPrimaryQueryManager<
       (params: any) =>
         Promise.resolve(
           _.map(
-            iterableFilter(
-              secondaryModelManagerMock.store.values(),
-              (entity) => entity.name.startsWith(params.name[0]),
+            iterableFilter(secondaryModelManagerMock.store.values(), (entity) =>
+              entity.name.startsWith(params.name[0]),
             ),
             (entity) => entity.id,
           ),

--- a/src/test/primary/query/names-starting-by-letter.ts
+++ b/src/test/primary/query/names-starting-by-letter.ts
@@ -1,8 +1,9 @@
 import * as _ from 'lodash';
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
-import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
+import { Model } from '../../../model/model';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
+import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 import { SecondaryEntityManagerMock } from '../../../testapi/api/secondary/secondary-entity-manager-mock';
 import { iterableFilter } from '../../util/iterable-filter';
 
@@ -16,13 +17,13 @@ export class NamesStartingByLetter extends AntMultipleResultPrimaryQueryManager<
 
   /**
    * Creates a new NamesStartingByLetter.
-   * @param primaryEntityManager Primary entity manager.
+   * @param manager Primary entity manager.
    * @param redis Redis connection.
    * @param reverseHashKey Reverse hash key.
    * @param prefix Query prefix.
    */
   public constructor(
-    primaryEntityManager: PrimaryEntityManager<NamedEntity>,
+    manager: SchedulerModelManager<NamedEntity, Model<NamedEntity>>,
     secondaryModelManagerMock: SecondaryEntityManagerMock<NamedEntity>,
     redis: RedisMiddleware,
     reverseHashKey: string,
@@ -50,7 +51,7 @@ export class NamesStartingByLetter extends AntMultipleResultPrimaryQueryManager<
             (entity) => entity.id,
           ),
         ),
-      primaryEntityManager,
+      manager,
       redis,
       reverseHashKey,
       key,

--- a/src/test/primary/query/names-starting-by-letter.ts
+++ b/src/test/primary/query/names-starting-by-letter.ts
@@ -43,7 +43,15 @@ export class NamesStartingByLetter extends AntMultipleResultPrimaryQueryManager<
       (params: any) =>
         Promise.resolve(
           _.map(
-            secondaryModelManagerMock.store.filter((entity) => entity.name.startsWith(params.name[0])),
+            ((): Entity[] => {
+              const filteredEntities = new Array();
+              for (const entity of secondaryModelManagerMock.store.values()) {
+                if (entity.name.startsWith(params.name[0])) {
+                  filteredEntities.push(entity);
+                }
+              }
+              return filteredEntities;
+            })(),
             (entity) => entity.id,
           ),
         ),

--- a/src/test/primary/query/names-starting-by-letter.ts
+++ b/src/test/primary/query/names-starting-by-letter.ts
@@ -4,6 +4,7 @@ import { Entity } from '../../../model/entity';
 import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
 import { SecondaryEntityManagerMock } from '../../../testapi/api/secondary/secondary-entity-manager-mock';
+import { iterableFilter } from '../../util/iterable-filter';
 
 export type NamedEntity = { id: number; name: string } & Entity;
 
@@ -43,15 +44,10 @@ export class NamesStartingByLetter extends AntMultipleResultPrimaryQueryManager<
       (params: any) =>
         Promise.resolve(
           _.map(
-            ((): Entity[] => {
-              const filteredEntities = new Array();
-              for (const entity of secondaryModelManagerMock.store.values()) {
-                if (entity.name.startsWith(params.name[0])) {
-                  filteredEntities.push(entity);
-                }
-              }
-              return filteredEntities;
-            })(),
+            iterableFilter(
+              secondaryModelManagerMock.store.values(),
+              (entity) => entity.name.startsWith(params.name[0]),
+            ),
             (entity) => entity.id,
           ),
         ),

--- a/src/test/primary/query/names-starting-by-letter.ts
+++ b/src/test/primary/query/names-starting-by-letter.ts
@@ -2,8 +2,8 @@ import * as _ from 'lodash';
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
+import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
-import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 import { SecondaryEntityManagerMock } from '../../../testapi/api/secondary/secondary-entity-manager-mock';
 import { iterableFilter } from '../../util/iterable-filter';
 
@@ -23,7 +23,8 @@ export class NamesStartingByLetter extends AntMultipleResultPrimaryQueryManager<
    * @param prefix Query prefix.
    */
   public constructor(
-    manager: SchedulerModelManager<NamedEntity, Model<NamedEntity>>,
+    model: Model<NamedEntity>,
+    manager: PrimaryEntityManager<NamedEntity>,
     secondaryModelManagerMock: SecondaryEntityManagerMock<NamedEntity>,
     redis: RedisMiddleware,
     reverseHashKey: string,
@@ -42,6 +43,8 @@ export class NamesStartingByLetter extends AntMultipleResultPrimaryQueryManager<
       }
     };
     super(
+      model,
+      manager,
       (params: any) =>
         Promise.resolve(
           _.map(
@@ -51,7 +54,6 @@ export class NamesStartingByLetter extends AntMultipleResultPrimaryQueryManager<
             (entity) => entity.id,
           ),
         ),
-      manager,
       redis,
       reverseHashKey,
       key,

--- a/src/test/primary/query/single-result-query-by-field-manager.ts
+++ b/src/test/primary/query/single-result-query-by-field-manager.ts
@@ -1,7 +1,8 @@
 import { AntSingleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-single-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
-import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
+import { Model } from '../../../model/model';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
+import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 
 export class SingleResultQueryByFieldManager<TEntity extends Entity> extends AntSingleResultPrimaryQueryManager<
   TEntity
@@ -18,7 +19,7 @@ export class SingleResultQueryByFieldManager<TEntity extends Entity> extends Ant
   /**
    * Creates a query by field manager.
    * @param query Query.
-   * @param primaryEntityManager Primary entity manager.
+   * @param manager Primary entity manager.
    * @param redis Redis connection.
    * @param reverseHashKey Reverse hash key.
    * @param field Query field.
@@ -27,7 +28,7 @@ export class SingleResultQueryByFieldManager<TEntity extends Entity> extends Ant
    */
   public constructor(
     query: (params: any) => Promise<number | string>,
-    primaryEntityManager: PrimaryEntityManager<TEntity>,
+    manager: SchedulerModelManager<TEntity, Model<TEntity>>,
     redis: RedisMiddleware,
     reverseHashKey: string,
     field: string,
@@ -42,7 +43,7 @@ export class SingleResultQueryByFieldManager<TEntity extends Entity> extends Ant
     const key = (param: any): string => {
       return this._queryPrefix + param[this._field];
     };
-    super(query, primaryEntityManager, redis, reverseHashKey, key, key, mQuery);
+    super(query, manager, redis, reverseHashKey, key, key, mQuery);
     this._field = field;
     this._queryPrefix = queryPrefix;
   }

--- a/src/test/primary/query/single-result-query-by-field-manager.ts
+++ b/src/test/primary/query/single-result-query-by-field-manager.ts
@@ -1,8 +1,8 @@
 import { AntSingleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-single-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
+import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
-import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 
 export class SingleResultQueryByFieldManager<TEntity extends Entity> extends AntSingleResultPrimaryQueryManager<
   TEntity
@@ -17,18 +17,12 @@ export class SingleResultQueryByFieldManager<TEntity extends Entity> extends Ant
   protected _queryPrefix: string;
 
   /**
-   * Creates a query by field manager.
-   * @param query Query.
-   * @param manager Primary entity manager.
-   * @param redis Redis connection.
-   * @param reverseHashKey Reverse hash key.
-   * @param field Query field.
-   * @param queryPrefix Query prefix.
-   * @param mQuery Multiple result query.
+   * @inheritdoc
    */
   public constructor(
+    model: Model<TEntity>,
+    manager: PrimaryEntityManager<TEntity>,
     query: (params: any) => Promise<number | string>,
-    manager: SchedulerModelManager<TEntity, Model<TEntity>>,
     redis: RedisMiddleware,
     reverseHashKey: string,
     field: string,
@@ -43,7 +37,7 @@ export class SingleResultQueryByFieldManager<TEntity extends Entity> extends Ant
     const key = (param: any): string => {
       return this._queryPrefix + param[this._field];
     };
-    super(query, manager, redis, reverseHashKey, key, key, mQuery);
+    super(model, manager, query, redis, reverseHashKey, key, key, mQuery);
     this._field = field;
     this._queryPrefix = queryPrefix;
   }

--- a/src/test/primary/query/single-result-query-manager-test.ts
+++ b/src/test/primary/query/single-result-query-manager-test.ts
@@ -22,10 +22,7 @@ const entityByFieldParam = <T extends number | string>(
   model: Model<Entity>,
   secondaryEntityManager: SecondaryEntityManagerMock<Entity>,
 ) => (params: any): Promise<T> => {
-  const entity = iterableFind(
-    secondaryEntityManager.store.values(),
-    (entity) => params.field === entity.field,
-  );
+  const entity = iterableFind(secondaryEntityManager.store.values(), (entity) => params.field === entity.field);
   return Promise.resolve(entity ? entity[model.id] : null);
 };
 

--- a/src/test/primary/query/single-result-query-manager-test.ts
+++ b/src/test/primary/query/single-result-query-manager-test.ts
@@ -74,11 +74,7 @@ export class SingleResultQueryManagerTest implements Test {
   private _helperGenerateBaseInstances(
     prefix: string,
     entities: EntityTestStr[],
-  ): [
-    Model<EntityTestStr>,
-    PrimaryModelManager<EntityTestStr>,
-    SecondaryEntityManagerMock<EntityTestStr>,
-  ] {
+  ): [Model<EntityTestStr>, PrimaryModelManager<EntityTestStr>, SecondaryEntityManagerMock<EntityTestStr>] {
     const model = new AntModel<EntityTestStr>('id', { prefix });
     const secondaryEntityManager = new SecondaryEntityManagerMock<EntityTestStr>(model, entities);
     const primaryManager = new AntPrimaryModelManager(model, this._redis.redis, true, secondaryEntityManager);
@@ -259,7 +255,7 @@ export class SingleResultQueryManagerTest implements Test {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
         const entity2: EntityTestStr = { field: 'sample-2', id: 2 };
-        const [model, primaryManager , secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
+        const [model, primaryManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
           entity1,
           entity2,
         ]);
@@ -431,10 +427,7 @@ export class SingleResultQueryManagerTest implements Test {
       async (done) => {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
-        const [model, primaryManager, secondaryEntityManager] = this._helperGenerateBaseInstances(
-          prefix,
-          new Array(),
-        );
+        const [model, primaryManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, new Array());
         const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           model,
@@ -462,10 +455,7 @@ export class SingleResultQueryManagerTest implements Test {
       async (done) => {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
-        const [model, primaryManager, secondaryEntityManager] = this._helperGenerateBaseInstances(
-          prefix,
-          new Array(),
-        );
+        const [model, primaryManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, new Array());
         const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           model,
@@ -491,10 +481,7 @@ export class SingleResultQueryManagerTest implements Test {
       itsName,
       async (done) => {
         await this._beforeAllPromise;
-        const [model, primaryManager, secondaryEntityManager] = this._helperGenerateBaseInstances(
-          prefix,
-          new Array(),
-        );
+        const [model, primaryManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, new Array());
         const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           model,
@@ -548,10 +535,7 @@ export class SingleResultQueryManagerTest implements Test {
       async (done) => {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
-        const [model, primaryManager, secondaryEntityManager] = this._helperGenerateBaseInstances(
-          prefix,
-          new Array(),
-        );
+        const [model, primaryManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, new Array());
         const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           model,
@@ -579,10 +563,7 @@ export class SingleResultQueryManagerTest implements Test {
       async (done) => {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
-        const [model, primaryManager, secondaryEntityManager] = this._helperGenerateBaseInstances(
-          prefix,
-          new Array(),
-        );
+        const [model, primaryManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, new Array());
         const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           model,

--- a/src/test/primary/query/single-result-query-manager-test.ts
+++ b/src/test/primary/query/single-result-query-manager-test.ts
@@ -9,12 +9,24 @@ import { SecondaryEntityManager } from '../../../persistence/secondary/secondary
 import { SecondaryEntityManagerMock } from '../../../testapi/api/secondary/secondary-entity-manager-mock';
 import { SingleResultQueryByFieldManager } from './single-result-query-by-field-manager';
 import { Test } from '../../../testapi/api/test';
+import { iterableFind } from '../../util/iterable-find';
 
 const MAX_SAFE_TIMEOUT = Math.pow(2, 31) - 1;
 
 type EntityTestStr = Entity & {
   id: number;
   field: string;
+};
+
+const entityByFieldParam = <T extends number | string>(
+  model: Model<Entity>,
+  secondaryEntityManager: SecondaryEntityManagerMock<Entity>,
+) => (params: any): Promise<T> => {
+  const entity = iterableFind(
+    secondaryEntityManager.store.values(),
+    (entity) => params.field === entity.field,
+  );
+  return Promise.resolve(entity ? entity[model.id] : null);
 };
 
 export class SingleResultQueryManagerTest implements Test {
@@ -133,16 +145,7 @@ export class SingleResultQueryManagerTest implements Test {
           true,
           secondaryEntityManager,
         );
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -174,16 +177,7 @@ export class SingleResultQueryManagerTest implements Test {
         const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
           entity1,
         ]);
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -213,16 +207,7 @@ export class SingleResultQueryManagerTest implements Test {
           entity1,
         ]);
         const modelManager = new AntPrimaryModelManager(model, this._redis.redis, false, secondaryEntityManager);
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -263,16 +248,7 @@ export class SingleResultQueryManagerTest implements Test {
           secondaryEntityManager,
         );
         const modelManager = new AntPrimaryModelManager(model, this._redis.redis, false, secondaryEntityManager);
-        const query = (params: any): Promise<string> =>
-          new Promise<string>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -304,16 +280,7 @@ export class SingleResultQueryManagerTest implements Test {
           entity1,
           entity2,
         ]);
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const mQuery = async (paramsArray: any[]): Promise<number[]> => {
           const results = new Array<number>(paramsArray.length);
           const resultsMap = new Map<string, number>();
@@ -358,16 +325,7 @@ export class SingleResultQueryManagerTest implements Test {
         const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
           entity1,
         ]);
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -397,16 +355,7 @@ export class SingleResultQueryManagerTest implements Test {
           entity1,
         ]);
         const modelManager = new AntPrimaryModelManager(model, this._redis.redis, false, secondaryEntityManager);
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -447,16 +396,7 @@ export class SingleResultQueryManagerTest implements Test {
           secondaryEntityManager,
         );
         const modelManager = new AntPrimaryModelManager(model, this._redis.redis, false, secondaryEntityManager);
-        const query = (params: any): Promise<string> =>
-          new Promise<string>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -488,16 +428,7 @@ export class SingleResultQueryManagerTest implements Test {
           entity1,
           entity2,
         ]);
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -527,16 +458,7 @@ export class SingleResultQueryManagerTest implements Test {
           prefix,
           new Array(),
         );
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -566,16 +488,7 @@ export class SingleResultQueryManagerTest implements Test {
           prefix,
           new Array(),
         );
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -603,16 +516,7 @@ export class SingleResultQueryManagerTest implements Test {
           prefix,
           new Array(),
         );
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -640,16 +544,7 @@ export class SingleResultQueryManagerTest implements Test {
         const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
           entity1,
         ]);
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -678,16 +573,7 @@ export class SingleResultQueryManagerTest implements Test {
           prefix,
           new Array(),
         );
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -717,16 +603,7 @@ export class SingleResultQueryManagerTest implements Test {
           prefix,
           new Array(),
         );
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -756,16 +633,7 @@ export class SingleResultQueryManagerTest implements Test {
         ]);
         const modelManager = new AntPrimaryModelManager(model, this._redis.redis, true, secondaryEntityManager);
         modelManager.delete(entity1[model.id]);
-        const query = (params: any): Promise<number> =>
-          new Promise<number>((resolve) => {
-            for (const entity of secondaryEntityManager.store.values()) {
-              if (params.field === entity.field) {
-                resolve(entity[model.id]);
-                return;
-              }
-            }
-            resolve(null);
-          });
+        const query = entityByFieldParam(model, secondaryEntityManager);
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,

--- a/src/test/primary/query/single-result-query-manager-test.ts
+++ b/src/test/primary/query/single-result-query-manager-test.ts
@@ -133,14 +133,16 @@ export class SingleResultQueryManagerTest implements Test {
           true,
           secondaryEntityManager,
         );
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -169,15 +171,19 @@ export class SingleResultQueryManagerTest implements Test {
       async (done) => {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
-        const [, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [entity1]);
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
+          entity1,
+        ]);
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -207,14 +213,16 @@ export class SingleResultQueryManagerTest implements Test {
           entity1,
         ]);
         const modelManager = new AntPrimaryModelManager(model, this._redis.redis, false, secondaryEntityManager);
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -225,6 +233,7 @@ export class SingleResultQueryManagerTest implements Test {
         );
         await queryManager.get({ field: entity1.field });
         await modelManager.delete(entity1.id);
+        secondaryEntityManager.store.set(entity1[model.id], entity1);
         const entityFound = await queryManager.get({ field: entity1.field });
         expect(entityFound).toEqual(entity1);
         done();
@@ -254,14 +263,16 @@ export class SingleResultQueryManagerTest implements Test {
           secondaryEntityManager,
         );
         const modelManager = new AntPrimaryModelManager(model, this._redis.redis, false, secondaryEntityManager);
-        const query = async (params: any): Promise<string> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const query = (params: any): Promise<string> =>
+          new Promise<string>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -289,18 +300,20 @@ export class SingleResultQueryManagerTest implements Test {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
         const entity2: EntityTestStr = { field: 'sample-2', id: 2 };
-        const [, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
+        const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
           entity1,
           entity2,
         ]);
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const mQuery = async (paramsArray: any[]): Promise<number[]> => {
           const results = new Array<number>(paramsArray.length);
           const resultsMap = new Map<string, number>();
@@ -308,7 +321,7 @@ export class SingleResultQueryManagerTest implements Test {
             results[i] = null;
             resultsMap.set(paramsArray[i].field, i);
           }
-          for (const entity of secondaryEntityManager.store) {
+          for (const entity of secondaryEntityManager.store.values()) {
             const index = resultsMap.get(entity.field);
             if (null != index) {
               results[index] = entity.id;
@@ -342,15 +355,19 @@ export class SingleResultQueryManagerTest implements Test {
       async (done) => {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
-        const [, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [entity1]);
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
+          entity1,
+        ]);
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -380,14 +397,16 @@ export class SingleResultQueryManagerTest implements Test {
           entity1,
         ]);
         const modelManager = new AntPrimaryModelManager(model, this._redis.redis, false, secondaryEntityManager);
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -398,6 +417,7 @@ export class SingleResultQueryManagerTest implements Test {
         );
         await queryManager.mGet([{ field: entity1.field }]);
         await modelManager.delete(entity1.id);
+        secondaryEntityManager.store.set(entity1[model.id], entity1);
         const entitiesFound = await queryManager.mGet([{ field: entity1.field }]);
         expect(entitiesFound).toEqual([entity1]);
         done();
@@ -427,14 +447,16 @@ export class SingleResultQueryManagerTest implements Test {
           secondaryEntityManager,
         );
         const modelManager = new AntPrimaryModelManager(model, this._redis.redis, false, secondaryEntityManager);
-        const query = async (params: any): Promise<string> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const query = (params: any): Promise<string> =>
+          new Promise<string>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -462,18 +484,20 @@ export class SingleResultQueryManagerTest implements Test {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
         const entity2: EntityTestStr = { field: 'sample-2', id: 2 };
-        const [, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
+        const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
           entity1,
           entity2,
         ]);
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -499,15 +523,20 @@ export class SingleResultQueryManagerTest implements Test {
       async (done) => {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
-        const [, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, new Array());
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(
+          prefix,
+          new Array(),
+        );
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -533,15 +562,20 @@ export class SingleResultQueryManagerTest implements Test {
       async (done) => {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
-        const [, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, new Array());
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(
+          prefix,
+          new Array(),
+        );
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -565,15 +599,20 @@ export class SingleResultQueryManagerTest implements Test {
       itsName,
       async (done) => {
         await this._beforeAllPromise;
-        const [, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, new Array());
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(
+          prefix,
+          new Array(),
+        );
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -598,15 +637,19 @@ export class SingleResultQueryManagerTest implements Test {
       async (done) => {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
-        const [, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [entity1]);
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, [
+          entity1,
+        ]);
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -631,15 +674,20 @@ export class SingleResultQueryManagerTest implements Test {
       async (done) => {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
-        const [, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, new Array());
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(
+          prefix,
+          new Array(),
+        );
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -665,15 +713,20 @@ export class SingleResultQueryManagerTest implements Test {
       async (done) => {
         await this._beforeAllPromise;
         const entity1: EntityTestStr = { field: 'sample-1', id: 1 };
-        const [, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(prefix, new Array());
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const [model, primaryEntityManager, secondaryEntityManager] = this._helperGenerateBaseInstances(
+          prefix,
+          new Array(),
+        );
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,
@@ -703,14 +756,16 @@ export class SingleResultQueryManagerTest implements Test {
         ]);
         const modelManager = new AntPrimaryModelManager(model, this._redis.redis, true, secondaryEntityManager);
         modelManager.delete(entity1[model.id]);
-        const query = async (params: any): Promise<number> => {
-          const entityFound = secondaryEntityManager.store.find((entity) => params.field === entity.field);
-          if (null == entityFound) {
-            return null;
-          } else {
-            return entityFound.id;
-          }
-        };
+        const query = (params: any): Promise<number> =>
+          new Promise<number>((resolve) => {
+            for (const entity of secondaryEntityManager.store.values()) {
+              if (params.field === entity.field) {
+                resolve(entity[model.id]);
+                return;
+              }
+            }
+            resolve(null);
+          });
         const queryManager = new SingleResultQueryByFieldManager(
           query,
           primaryEntityManager,

--- a/src/test/scheduler/ant-scheduler-mode-manager-test.ts
+++ b/src/test/scheduler/ant-scheduler-mode-manager-test.ts
@@ -40,120 +40,122 @@ export class AntSchedulerModelManagerTest implements Test {
   private _itMustCallPrimaryManagerMethods(): void {
     const itsName = 'must call primary manager methods';
     const prefix = this._declareName + '/' + itsName + '/';
-    it(itsName, async (done) => {
-      const model = new AntModel('id', { prefix });
-      const [ primaryManager, secondaryManager ] = this._modelManagerGenerator.generateModelManager({ model });
-      const schedulerModelManager = new AntScheduleModelManager(model, primaryManager, secondaryManager);
+    it(
+      itsName,
+      async (done) => {
+        const model = new AntModel('id', { prefix });
+        const [primaryManager, secondaryManager] = this._modelManagerGenerator.generateModelManager({ model });
+        const schedulerModelManager = new AntScheduleModelManager(model, primaryManager, secondaryManager);
 
-      const methodsToTestAtPrimary: Array<keyof PrimaryModelManager<any>> = [
-        'delete',
-        'get',
-        'mDelete',
-        'mGet',
-      ];
-      for (const methodToTest of methodsToTestAtPrimary) {
-        spyOn(primaryManager, methodToTest as any).and.returnValue(Promise.resolve(methodToTest) as any);
-      }
+        const methodsToTestAtPrimary: Array<keyof PrimaryModelManager<any>> = ['delete', 'get', 'mDelete', 'mGet'];
+        for (const methodToTest of methodsToTestAtPrimary) {
+          spyOn(primaryManager, methodToTest as any).and.returnValue(Promise.resolve(methodToTest) as any);
+        }
 
-      const entity: Entity = { id: 0 };
+        const entity: Entity = { id: 0 };
 
-      const [deleteResult, getResult, mDeleteResult, mGetResult] = await Promise.all([
-        schedulerModelManager.delete(entity.id),
-        schedulerModelManager.get(entity.id),
-        schedulerModelManager.mDelete([entity.id]),
-        schedulerModelManager.mGet([entity.id]),
-      ]);
+        const [deleteResult, getResult, mDeleteResult, mGetResult] = await Promise.all([
+          schedulerModelManager.delete(entity.id),
+          schedulerModelManager.get(entity.id),
+          schedulerModelManager.mDelete([entity.id]),
+          schedulerModelManager.mGet([entity.id]),
+        ]);
 
-      const results: { [key: string]: any } = {
-        delete: deleteResult,
-        get: getResult,
-        mDelete: mDeleteResult,
-        mGet: mGetResult,
-      };
+        const results: { [key: string]: any } = {
+          delete: deleteResult,
+          get: getResult,
+          mDelete: mDeleteResult,
+          mGet: mGetResult,
+        };
 
-      for (const methodToTest of methodsToTestAtPrimary) {
-        expect(primaryManager[methodToTest]).toHaveBeenCalled();
-        expect(results[methodToTest]).toBe(methodToTest);
-      }
+        for (const methodToTest of methodsToTestAtPrimary) {
+          expect(primaryManager[methodToTest]).toHaveBeenCalled();
+          expect(results[methodToTest]).toBe(methodToTest);
+        }
 
-      done();
-    }, MAX_SAFE_TIMEOUT);
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
   }
 
   private _itMustCallPrimaryManagerMethodsEvenIfNoSecondaryManagerIsProvided(): void {
     const itsName = 'must call primary manager methods';
     const prefix = this._declareName + '/' + itsName + '/';
-    it(itsName, async (done) => {
-      const model = new AntModel('id', { prefix });
-      const [ primaryManager ] = this._modelManagerGenerator.generateModelManager({ model });
-      const schedulerModelManager = new AntScheduleModelManager(model, primaryManager);
+    it(
+      itsName,
+      async (done) => {
+        const model = new AntModel('id', { prefix });
+        const [primaryManager] = this._modelManagerGenerator.generateModelManager({ model });
+        const schedulerModelManager = new AntScheduleModelManager(model, primaryManager);
 
-      const methodsToTestAtPrimary: Array<keyof PrimaryModelManager<any>> = [
-        'delete',
-        'get',
-        'mDelete',
-        'mGet',
-      ];
-      for (const methodToTest of methodsToTestAtPrimary) {
-        spyOn(primaryManager, methodToTest as any).and.returnValue(Promise.resolve(methodToTest) as any);
-      }
+        const methodsToTestAtPrimary: Array<keyof PrimaryModelManager<any>> = ['delete', 'get', 'mDelete', 'mGet'];
+        for (const methodToTest of methodsToTestAtPrimary) {
+          spyOn(primaryManager, methodToTest as any).and.returnValue(Promise.resolve(methodToTest) as any);
+        }
 
-      const entity: Entity = { id: 0 };
+        const entity: Entity = { id: 0 };
 
-      const [deleteResult, getResult, mDeleteResult, mGetResult] = await Promise.all([
-        schedulerModelManager.delete(entity.id),
-        schedulerModelManager.get(entity.id),
-        schedulerModelManager.mDelete([entity.id]),
-        schedulerModelManager.mGet([entity.id]),
-      ]);
+        const [deleteResult, getResult, mDeleteResult, mGetResult] = await Promise.all([
+          schedulerModelManager.delete(entity.id),
+          schedulerModelManager.get(entity.id),
+          schedulerModelManager.mDelete([entity.id]),
+          schedulerModelManager.mGet([entity.id]),
+        ]);
 
-      const results: { [key: string]: any } = {
-        delete: deleteResult,
-        get: getResult,
-        mDelete: mDeleteResult,
-        mGet: mGetResult,
-      };
+        const results: { [key: string]: any } = {
+          delete: deleteResult,
+          get: getResult,
+          mDelete: mDeleteResult,
+          mGet: mGetResult,
+        };
 
-      for (const methodToTest of methodsToTestAtPrimary) {
-        expect(primaryManager[methodToTest]).toHaveBeenCalled();
-        expect(results[methodToTest]).toBe(methodToTest);
-      }
+        for (const methodToTest of methodsToTestAtPrimary) {
+          expect(primaryManager[methodToTest]).toHaveBeenCalled();
+          expect(results[methodToTest]).toBe(methodToTest);
+        }
 
-      done();
-    }, MAX_SAFE_TIMEOUT);
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
   }
 
   private _itMustCallSecondaryManagerMethods(): void {
     const itsName = 'must call secondary manager methods';
     const prefix = this._declareName + '/' + itsName + '/';
-    it(itsName, async (done) => {
-      const model = new AntModel('id', { prefix });
-      const [ primaryManager, secondaryManager ] = this._modelManagerGenerator.generateModelManager({ model });
-      const schedulerModelManager = new AntScheduleModelManager(model, primaryManager, secondaryManager);
+    it(
+      itsName,
+      async (done) => {
+        const model = new AntModel('id', { prefix });
+        const [primaryManager, secondaryManager] = this._modelManagerGenerator.generateModelManager({ model });
+        const schedulerModelManager = new AntScheduleModelManager(model, primaryManager, secondaryManager);
 
-      const methodsToTestAtPrimary: Array<keyof SecondaryEntityManager<any>> = [
-        'delete',
-        'getById',
-        'getByIds',
-        'mDelete',
-      ];
-      for (const methodToTest of methodsToTestAtPrimary) {
-        spyOn(secondaryManager, methodToTest as any).and.callThrough();
-      }
+        const methodsToTestAtPrimary: Array<keyof SecondaryEntityManager<any>> = [
+          'delete',
+          'getById',
+          'getByIds',
+          'mDelete',
+        ];
+        for (const methodToTest of methodsToTestAtPrimary) {
+          spyOn(secondaryManager, methodToTest as any).and.callThrough();
+        }
 
-      const entity: Entity = { id: 0 };
+        const entity: Entity = { id: 0 };
 
-      await Promise.all([
-        schedulerModelManager.delete(entity.id),
-        schedulerModelManager.get(entity.id),
-        schedulerModelManager.mDelete([entity.id]),
-        schedulerModelManager.mGet([entity.id]),
-      ]);
-      for (const methodToTest of methodsToTestAtPrimary) {
-        expect(secondaryManager[methodToTest]).toHaveBeenCalled();
-      }
+        await Promise.all([
+          schedulerModelManager.delete(entity.id),
+          schedulerModelManager.get(entity.id),
+          schedulerModelManager.mDelete([entity.id]),
+          schedulerModelManager.mGet([entity.id]),
+        ]);
+        for (const methodToTest of methodsToTestAtPrimary) {
+          expect(secondaryManager[methodToTest]).toHaveBeenCalled();
+        }
 
-      done();
-    }, MAX_SAFE_TIMEOUT);
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
   }
 }

--- a/src/test/scheduler/ant-scheduler-mode-manager-test.ts
+++ b/src/test/scheduler/ant-scheduler-mode-manager-test.ts
@@ -1,0 +1,159 @@
+import { AntJsModelManagerGenerator } from '../../testapi/api/generator/antjs-model-manager-generator';
+import { AntModel } from '../../model/ant-model';
+import { AntScheduleModelManager } from '../../persistence/scheduler/ant-scheduler-model-manager';
+import { Entity } from '../../model/entity';
+import { PrimaryModelManager } from '../../persistence/primary/primary-model-manager';
+import { RedisWrapper } from '../primary/redis-wrapper';
+import { SecondaryEntityManager } from '../../persistence/secondary/secondary-entity-manager';
+import { Test } from '../../testapi/api/test';
+
+const MAX_SAFE_TIMEOUT = Math.pow(2, 31) - 1;
+
+export class AntSchedulerModelManagerTest implements Test {
+  /**
+   * Before all task performed promise.
+   */
+  protected _beforeAllPromise: Promise<any>;
+  /**
+   * Declare name for the test
+   */
+  protected _declareName: string;
+  /**
+   * Model manager generator.
+   */
+  protected _modelManagerGenerator: AntJsModelManagerGenerator;
+
+  public constructor(beforeAllPromise: Promise<any>) {
+    this._beforeAllPromise = beforeAllPromise;
+    this._declareName = AntSchedulerModelManagerTest.name;
+    this._modelManagerGenerator = new AntJsModelManagerGenerator(new RedisWrapper().redis);
+  }
+
+  public performTests(): void {
+    describe(this._declareName, () => {
+      this._itMustCallPrimaryManagerMethods();
+      this._itMustCallPrimaryManagerMethodsEvenIfNoSecondaryManagerIsProvided();
+      this._itMustCallSecondaryManagerMethods();
+    });
+  }
+
+  private _itMustCallPrimaryManagerMethods(): void {
+    const itsName = 'must call primary manager methods';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(itsName, async (done) => {
+      const model = new AntModel('id', { prefix });
+      const [ primaryManager, secondaryManager ] = this._modelManagerGenerator.generateModelManager({ model });
+      const schedulerModelManager = new AntScheduleModelManager(model, primaryManager, secondaryManager);
+
+      const methodsToTestAtPrimary: Array<keyof PrimaryModelManager<any>> = [
+        'delete',
+        'get',
+        'mDelete',
+        'mGet',
+      ];
+      for (const methodToTest of methodsToTestAtPrimary) {
+        spyOn(primaryManager, methodToTest as any).and.returnValue(Promise.resolve(methodToTest) as any);
+      }
+
+      const entity: Entity = { id: 0 };
+
+      const [deleteResult, getResult, mDeleteResult, mGetResult] = await Promise.all([
+        schedulerModelManager.delete(entity.id),
+        schedulerModelManager.get(entity.id),
+        schedulerModelManager.mDelete([entity.id]),
+        schedulerModelManager.mGet([entity.id]),
+      ]);
+
+      const results: { [key: string]: any } = {
+        delete: deleteResult,
+        get: getResult,
+        mDelete: mDeleteResult,
+        mGet: mGetResult,
+      };
+
+      for (const methodToTest of methodsToTestAtPrimary) {
+        expect(primaryManager[methodToTest]).toHaveBeenCalled();
+        expect(results[methodToTest]).toBe(methodToTest);
+      }
+
+      done();
+    }, MAX_SAFE_TIMEOUT);
+  }
+
+  private _itMustCallPrimaryManagerMethodsEvenIfNoSecondaryManagerIsProvided(): void {
+    const itsName = 'must call primary manager methods';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(itsName, async (done) => {
+      const model = new AntModel('id', { prefix });
+      const [ primaryManager ] = this._modelManagerGenerator.generateModelManager({ model });
+      const schedulerModelManager = new AntScheduleModelManager(model, primaryManager);
+
+      const methodsToTestAtPrimary: Array<keyof PrimaryModelManager<any>> = [
+        'delete',
+        'get',
+        'mDelete',
+        'mGet',
+      ];
+      for (const methodToTest of methodsToTestAtPrimary) {
+        spyOn(primaryManager, methodToTest as any).and.returnValue(Promise.resolve(methodToTest) as any);
+      }
+
+      const entity: Entity = { id: 0 };
+
+      const [deleteResult, getResult, mDeleteResult, mGetResult] = await Promise.all([
+        schedulerModelManager.delete(entity.id),
+        schedulerModelManager.get(entity.id),
+        schedulerModelManager.mDelete([entity.id]),
+        schedulerModelManager.mGet([entity.id]),
+      ]);
+
+      const results: { [key: string]: any } = {
+        delete: deleteResult,
+        get: getResult,
+        mDelete: mDeleteResult,
+        mGet: mGetResult,
+      };
+
+      for (const methodToTest of methodsToTestAtPrimary) {
+        expect(primaryManager[methodToTest]).toHaveBeenCalled();
+        expect(results[methodToTest]).toBe(methodToTest);
+      }
+
+      done();
+    }, MAX_SAFE_TIMEOUT);
+  }
+
+  private _itMustCallSecondaryManagerMethods(): void {
+    const itsName = 'must call secondary manager methods';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(itsName, async (done) => {
+      const model = new AntModel('id', { prefix });
+      const [ primaryManager, secondaryManager ] = this._modelManagerGenerator.generateModelManager({ model });
+      const schedulerModelManager = new AntScheduleModelManager(model, primaryManager, secondaryManager);
+
+      const methodsToTestAtPrimary: Array<keyof SecondaryEntityManager<any>> = [
+        'delete',
+        'getById',
+        'getByIds',
+        'mDelete',
+      ];
+      for (const methodToTest of methodsToTestAtPrimary) {
+        spyOn(secondaryManager, methodToTest as any).and.callThrough();
+      }
+
+      const entity: Entity = { id: 0 };
+
+      await Promise.all([
+        schedulerModelManager.delete(entity.id),
+        schedulerModelManager.get(entity.id),
+        schedulerModelManager.mDelete([entity.id]),
+        schedulerModelManager.mGet([entity.id]),
+      ]);
+      for (const methodToTest of methodsToTestAtPrimary) {
+        expect(secondaryManager[methodToTest]).toHaveBeenCalled();
+      }
+
+      done();
+    }, MAX_SAFE_TIMEOUT);
+  }
+}

--- a/src/test/util/iterable-filter.ts
+++ b/src/test/util/iterable-filter.ts
@@ -1,0 +1,11 @@
+export const iterableFilter = <T>(iterable: Iterable<T>, filter: (elem: T) => boolean): T[] => {
+  const filteredElements = new Array<T>();
+
+  for (const elem of iterable) {
+    if (filter(elem)) {
+      filteredElements.push(elem);
+    }
+  }
+
+  return filteredElements;
+};

--- a/src/test/util/iterable-find.ts
+++ b/src/test/util/iterable-find.ts
@@ -1,0 +1,8 @@
+export const iterableFind = <T>(iterable: Iterable<T>, filter: (elem: T) => boolean): T => {
+  for (const elem of iterable) {
+    if (filter(elem)) {
+      return elem;
+    }
+  }
+  return null;
+};

--- a/src/testapi/api/generator/antjs-model-manager-generator.ts
+++ b/src/testapi/api/generator/antjs-model-manager-generator.ts
@@ -49,11 +49,15 @@ export class AntJsModelManagerGenerator extends ModelManagerGenerator<
     property: string,
     value: any,
   ): Promise<TEntity[]> {
-    return Promise.resolve(
-      (secondaryManager as SecondaryEntityManagerMock<TEntity>).store.filter(
-        (entity: TEntity) => value === entity[property],
-      ),
-    );
+    return new Promise<TEntity[]>((resolve) => {
+      const entitiesByProperty = new Array<TEntity>();
+      for (const entity of (secondaryManager as SecondaryEntityManagerMock<TEntity>).store.values()) {
+        if (value === entity[property]) {
+          entitiesByProperty.push(entity);
+        }
+      }
+      resolve(entitiesByProperty);
+    });
   }
 
   /**
@@ -64,10 +68,14 @@ export class AntJsModelManagerGenerator extends ModelManagerGenerator<
     property: string,
     value: any,
   ): Promise<TEntity> {
-    return Promise.resolve(
-      (secondaryManager as SecondaryEntityManagerMock<TEntity>).store.find(
-        (entity: TEntity) => value === entity[property],
-      ),
-    );
+    return new Promise<TEntity>((resolve) => {
+      for (const entity of (secondaryManager as SecondaryEntityManagerMock<TEntity>).store.values()) {
+        if (value === entity[property]) {
+          resolve(entity);
+          return;
+        }
+      }
+      resolve(null);
+    });
   }
 }

--- a/src/testapi/api/generator/antjs-model-manager-generator.ts
+++ b/src/testapi/api/generator/antjs-model-manager-generator.ts
@@ -1,5 +1,4 @@
 import { AntPrimaryModelManager } from '../../../persistence/primary/ant-primary-model-manager';
-import { AntScheduleModelManager } from '../../../persistence/scheduler/ant-scheduler-model-manager';
 import { ApiModelManagerGeneratorOptions } from './api-model-manager-generator-options';
 import { ApiModelManagerGeneratorRedisOptions } from './api-model-manager-generator-redis-options';
 import { ApiModelManagerGeneratorSecodaryManagerOptions } from './api-model-manager-generator-secodary-manager-options';
@@ -7,7 +6,6 @@ import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
 import { ModelManagerGenerator } from './model-manager-generator';
 import { PrimaryModelManager } from '../../../persistence/primary/primary-model-manager';
-import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 import { SecondaryEntityManagerMock } from '../secondary/secondary-entity-manager-mock';
 
 type TModelManagerOptions = ApiModelManagerGeneratorOptions<
@@ -19,8 +17,7 @@ type TModelManagerOptions = ApiModelManagerGeneratorOptions<
 export class AntJsModelManagerGenerator extends ModelManagerGenerator<
   TModelManagerOptions,
   PrimaryModelManager<Entity>,
-  SecondaryEntityManagerMock<Entity>,
-  SchedulerModelManager<Entity, Model<Entity>>
+  SecondaryEntityManagerMock<Entity>
 > {
   /**
    * @inheritdoc
@@ -42,20 +39,6 @@ export class AntJsModelManagerGenerator extends ModelManagerGenerator<
       options.redisOptions.useEntityNegativeCache ?? true,
       secondaryManager,
     );
-  }
-
-  /**
-   * Generates an scheduler manager.
-   * @param options Generation options
-   * @param primaryManager Primary manager
-   * @param secondaryManager Secondary manager.
-   */
-  protected _generateSchedulerManager(
-    options: TModelManagerOptions,
-    primaryManager: PrimaryModelManager<Entity>,
-    secondaryManager: SecondaryEntityManagerMock<Entity>,
-  ): SchedulerModelManager<Entity, Model<Entity>> {
-    return new AntScheduleModelManager(options.model, primaryManager, secondaryManager);
   }
 
   /**

--- a/src/testapi/api/generator/antjs-model-manager-generator.ts
+++ b/src/testapi/api/generator/antjs-model-manager-generator.ts
@@ -1,4 +1,5 @@
 import { AntPrimaryModelManager } from '../../../persistence/primary/ant-primary-model-manager';
+import { AntScheduleModelManager } from '../../../persistence/scheduler/ant-scheduler-model-manager';
 import { ApiModelManagerGeneratorOptions } from './api-model-manager-generator-options';
 import { ApiModelManagerGeneratorRedisOptions } from './api-model-manager-generator-redis-options';
 import { ApiModelManagerGeneratorSecodaryManagerOptions } from './api-model-manager-generator-secodary-manager-options';
@@ -6,6 +7,7 @@ import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
 import { ModelManagerGenerator } from './model-manager-generator';
 import { PrimaryModelManager } from '../../../persistence/primary/primary-model-manager';
+import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 import { SecondaryEntityManagerMock } from '../secondary/secondary-entity-manager-mock';
 
 type TModelManagerOptions = ApiModelManagerGeneratorOptions<
@@ -17,8 +19,16 @@ type TModelManagerOptions = ApiModelManagerGeneratorOptions<
 export class AntJsModelManagerGenerator extends ModelManagerGenerator<
   TModelManagerOptions,
   PrimaryModelManager<Entity>,
-  SecondaryEntityManagerMock<Entity>
+  SecondaryEntityManagerMock<Entity>,
+  SchedulerModelManager<Entity, Model<Entity>>
 > {
+  /**
+   * @inheritdoc
+   */
+  protected _generateDefaultSecondaryManager(options: TModelManagerOptions): SecondaryEntityManagerMock<Entity> {
+    return new SecondaryEntityManagerMock(options.model);
+  }
+
   /**
    * @inheritdoc
    */
@@ -29,16 +39,23 @@ export class AntJsModelManagerGenerator extends ModelManagerGenerator<
     return new AntPrimaryModelManager(
       options.model,
       options.redisOptions.redis,
-      options.redisOptions.useEntityNegativeCache || true,
+      options.redisOptions.useEntityNegativeCache ?? true,
       secondaryManager,
     );
   }
 
   /**
-   * @inheritdoc
+   * Generates an scheduler manager.
+   * @param options Generation options
+   * @param primaryManager Primary manager
+   * @param secondaryManager Secondary manager.
    */
-  protected _generateDefaultSecondaryManager(options: TModelManagerOptions): SecondaryEntityManagerMock<Entity> {
-    return new SecondaryEntityManagerMock(options.model);
+  protected _generateSchedulerManager(
+    options: TModelManagerOptions,
+    primaryManager: PrimaryModelManager<Entity>,
+    secondaryManager: SecondaryEntityManagerMock<Entity>,
+  ): SchedulerModelManager<Entity, Model<Entity>> {
+    return new AntScheduleModelManager(options.model, primaryManager, secondaryManager);
   }
 
   /**

--- a/src/testapi/api/generator/model-manager-generator.ts
+++ b/src/testapi/api/generator/model-manager-generator.ts
@@ -21,7 +21,7 @@ export abstract class ModelManagerGenerator<
     ApiModelManagerGeneratorSecodaryManagerOptions<TSecondaryManager>
   >,
   TModelManager extends PrimaryModelManager<Entity>,
-  TSecondaryManager extends SecondaryEntityManager<Entity>,
+  TSecondaryManager extends SecondaryEntityManager<Entity>
 > {
   /**
    * Default redis middleware.

--- a/src/testapi/test/api/secondary/secondary-entity-manager-mock-test.ts
+++ b/src/testapi/test/api/secondary/secondary-entity-manager-mock-test.ts
@@ -111,7 +111,7 @@ export class SecondaryEntityManagerMockTest implements Test {
       const model = new AntModel('id', { prefix: '' });
       const store = [{ id: 0 }];
       const manager = new SecondaryEntityManagerMock(model, store);
-      expect(manager.store).toBe(store);
+      expect([...manager.store.values()]).toEqual(store);
       done();
     });
   }


### PR DESCRIPTION
- [x] Added a delete method to the secondary entity manager.
- [x] The AntJs API no longer provides a global update, even if the update method at the primary level remains unchanged.
- [x] Tests have been refactored. Common queries have been extracted to constants.
