### PR TITLE
Primary layer get refactor

### DIFF
--- a/docker-compose.test.debug.yml
+++ b/docker-compose.test.debug.yml
@@ -6,3 +6,6 @@ services:
       NODE_DEBUG_PORT_INNER: ${NODE_DEBUG_PORT_INNER}
     ports:
       - "${NODE_DEBUG_PORT_OUTER}:${NODE_DEBUG_PORT_INNER}"
+  ant_redis:
+    ports:
+      - "${REDIS_DEBUG_PORT_OUTER}:6379"

--- a/src/persistence/options/antjs-delete-options.ts
+++ b/src/persistence/options/antjs-delete-options.ts
@@ -1,8 +1,4 @@
-import {
-  DEFAULT_IGNORE_PRIMARY_LAYER,
-  DEFAULT_IGNORE_SECONDARY_LAYER,
-  DEFAULT_NEGATIVE_CACHE_OPTION,
-} from './default-options';
+import { DEFAULT_IGNORE_PRIMARY_LAYER, DEFAULT_IGNORE_SECONDARY_LAYER } from './default-options';
 import { PersistencyDeleteOptions } from './persistency-delete-options';
 
 export class AntJsDeleteOptions implements PersistencyDeleteOptions {
@@ -14,10 +10,6 @@ export class AntJsDeleteOptions implements PersistencyDeleteOptions {
    * @inheritdoc
    */
   public readonly ignoreSecondaryLayer: boolean;
-  /**
-   * @inheritdoc
-   */
-  public readonly negativeCache: boolean;
 
   /**
    * Creates new AntJS delete options.
@@ -26,6 +18,5 @@ export class AntJsDeleteOptions implements PersistencyDeleteOptions {
   public constructor(options: Partial<PersistencyDeleteOptions> = {}) {
     this.ignorePrimaryLayer = options.ignorePrimaryLayer ?? DEFAULT_IGNORE_PRIMARY_LAYER;
     this.ignoreSecondaryLayer = options.ignoreSecondaryLayer ?? DEFAULT_IGNORE_SECONDARY_LAYER;
-    this.negativeCache = options.negativeCache ?? DEFAULT_NEGATIVE_CACHE_OPTION;
   }
 }

--- a/src/persistence/options/antjs-search-options.ts
+++ b/src/persistence/options/antjs-search-options.ts
@@ -2,7 +2,6 @@ import {
   DEFAULT_CACHE_MODE_OPTION,
   DEFAULT_IGNORE_PRIMARY_LAYER,
   DEFAULT_IGNORE_SECONDARY_LAYER,
-  DEFAULT_NEGATIVE_CACHE_OPTION,
   DEFAULT_TTL_OPTION,
 } from './default-options';
 import { CacheMode } from './cache-mode';
@@ -24,10 +23,6 @@ export class AntJsSearchOptions implements PersistencySearchOptions {
   /**
    * @inheritdoc
    */
-  public readonly negativeCache: boolean;
-  /**
-   * @inheritdoc
-   */
   public readonly ttl: number;
 
   /**
@@ -39,7 +34,6 @@ export class AntJsSearchOptions implements PersistencySearchOptions {
     this.cacheMode = options.cacheMode ?? DEFAULT_CACHE_MODE_OPTION;
     this.ignorePrimaryLayer = options.ignorePrimaryLayer ?? DEFAULT_IGNORE_PRIMARY_LAYER;
     this.ignoreSecondaryLayer = options.ignoreSecondaryLayer ?? DEFAULT_IGNORE_SECONDARY_LAYER;
-    this.negativeCache = options.negativeCache ?? DEFAULT_NEGATIVE_CACHE_OPTION;
     this.ttl = options.ttl ?? DEFAULT_TTL_OPTION;
   }
 }

--- a/src/persistence/options/default-options.ts
+++ b/src/persistence/options/default-options.ts
@@ -3,5 +3,4 @@ import { CacheMode } from './cache-mode';
 export const DEFAULT_CACHE_MODE_OPTION = CacheMode.CacheAndOverwrite;
 export const DEFAULT_IGNORE_PRIMARY_LAYER = false;
 export const DEFAULT_IGNORE_SECONDARY_LAYER = false;
-export const DEFAULT_NEGATIVE_CACHE_OPTION = false;
 export const DEFAULT_TTL_OPTION: number = null;

--- a/src/persistence/options/persistency-delete-options.ts
+++ b/src/persistence/options/persistency-delete-options.ts
@@ -1,8 +1,3 @@
 import { PersistencyBaseOptions } from './persistency-base-options';
 
-export interface PersistencyDeleteOptions extends PersistencyBaseOptions {
-  /**
-   * True if negative cache must be used.
-   */
-  readonly negativeCache: boolean;
-}
+export interface PersistencyDeleteOptions extends PersistencyBaseOptions {}

--- a/src/persistence/primary/primary-entity-manager.ts
+++ b/src/persistence/primary/primary-entity-manager.ts
@@ -3,17 +3,44 @@ import { PersistencySearchOptions } from '../options/persistency-search-options'
 
 export interface PrimaryEntityManager<TEntity extends Entity> {
   /**
-   * Gets a model by its id.
-   * @param id: Model's id.
-   * @param options Cache options.
-   * @returns Model found.
+   * True to use negative entity cache.
    */
-  get(id: number | string, options: PersistencySearchOptions): Promise<TEntity>;
+  readonly negativeCache: boolean;
+  /**
+   * Caches an entity found after a cache miss.
+   * @param id Entity's id.
+   * @param entity Entity to cache or null if no entity was found.
+   * @param options Persistency options.
+   */
+  cacheMiss(id: number | string, entity: TEntity, options: PersistencySearchOptions): Promise<void>;
+  /**
+   * Entities to cache.
+   *
+   * If this manager has a negative cache strategy, ids and entities parameters must be sorted by id (ASC)
+   * If this manager doesn't have a negative cache strategy, entities[i][model.id] === id[i] is expected to be true.
+   *
+   * @param ids Ids of the entities to cache.
+   * @param entities Entities to cache.
+   * @param options Persistency options.
+   * @returns Promise of entities cached.
+   */
+  cacheMisses(ids: number[] | string[], entities: TEntity[], options: PersistencySearchOptions): Promise<void>;
+  /**
+   * Gets an entity at the cache layer by its id.
+   * @param id Entity's id
+   * @returns
+   *
+   * An entity if found.
+   *
+   * If the cache system is able to know that no entity has the requested id, a null value is returned.
+   * If the cache system is unable to know if no entity has the requested id, undefined is returned instead.
+   */
+  get(id: number | string): Promise<TEntity>;
   /**
    * Gets a collection of models by its ids.
    * @param ids Model ids.
    * @param options Cache options.
    * @returns Models found.
    */
-  mGet(ids: number[] | string[], options: PersistencySearchOptions): Promise<TEntity[]>;
+  mGet(ids: number[] | string[]): Promise<TEntity[]>;
 }

--- a/src/persistence/primary/primary-model-manager.ts
+++ b/src/persistence/primary/primary-model-manager.ts
@@ -1,5 +1,4 @@
 import { Entity } from '../../model/entity';
-import { PersistencyDeleteOptions } from '../options/persistency-delete-options';
 import { PersistencyUpdateOptions } from '../options/persistency-update-options';
 import { PrimaryEntityManager } from './primary-entity-manager';
 import { PrimaryQueryManager } from './query/primary-query-manager';
@@ -8,17 +7,15 @@ export interface BasePrimaryModelManager<TEntity extends Entity> extends Primary
   /**
    * Deletes an entity from the cache layer.
    * @param id id of the entity to delete.
-   * @param options Delete options.
    * @returns Promise of entity deleted.
    */
-  delete(id: number | string, options: PersistencyDeleteOptions): Promise<any>;
+  delete(id: number | string): Promise<any>;
   /**
    * Deletes multiple entities from the cache layer.
    * @param ids Ids of the entities to delete.
-   * @param options Delete options.
    * @returns Promise of entities deleted.
    */
-  mDelete(ids: number[] | string[], options: PersistencyDeleteOptions): Promise<any>;
+  mDelete(ids: number[] | string[]): Promise<any>;
   /**
    * Updates multiple entities at the cache layer.
    * @param entities Entities to be updated.

--- a/src/persistence/primary/query/ant-primary-query-manager.ts
+++ b/src/persistence/primary/query/ant-primary-query-manager.ts
@@ -4,8 +4,8 @@ import { BasePrimaryQueryManager } from './primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
 import { PersistencySearchOptions } from '../../options/persistency-search-options';
-import { PrimaryEntityManager } from '../primary-entity-manager';
 import { RedisMiddleware } from '../redis-middleware';
+import { SchedulerModelManager } from '../../scheduler/scheduler-model-manager';
 import { luaKeyGenerator } from '../lua-key-generator';
 
 export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResult extends QueryResult>
@@ -27,9 +27,9 @@ export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResul
    */
   protected _mquery: TMQuery<TQueryResult>;
   /**
-   * Primary entity manager.
+   * Model manager.
    */
-  protected _manager: PrimaryEntityManager<TEntity>;
+  protected _manager: SchedulerModelManager<TEntity>;
   /**
    * Query to obtain ids.
    */
@@ -59,7 +59,7 @@ export abstract class AntPrimaryQueryManager<TEntity extends Entity, TQueryResul
    */
   public constructor(
     model: Model<TEntity>,
-    manager: PrimaryEntityManager<TEntity>,
+    manager: SchedulerModelManager<TEntity>,
     query: TQuery<TQueryResult>,
     redis: RedisMiddleware,
     reverseHashKey: string,

--- a/src/persistence/primary/script/delete-entities-cached-script-set.ts
+++ b/src/persistence/primary/script/delete-entities-cached-script-set.ts
@@ -1,8 +1,7 @@
-import { PersistencyDeleteOptions } from '../../options/persistency-delete-options';
 import { RedisCachedScript } from './redis-cached-script';
 import { RedisCachedScriptSet } from './redis-cached-script-set';
 
-export class DeleteEntitiesCachedScriptSet implements RedisCachedScriptSet<PersistencyDeleteOptions> {
+export class DeleteEntitiesCachedScriptSet implements RedisCachedScriptSet<boolean> {
   /**
    * Map of keys to redis cached scripts.
    */
@@ -11,13 +10,13 @@ export class DeleteEntitiesCachedScriptSet implements RedisCachedScriptSet<Persi
   /**
    * RedisCachedScript generator.
    */
-  protected _generator: (mode: PersistencyDeleteOptions) => RedisCachedScript;
+  protected _generator: (negativeCache: boolean) => RedisCachedScript;
 
   /**
    * Creates a new Redis cached script set by cache mode.
    * @param generator Cached script generator.
    */
-  public constructor(generator: (mode: PersistencyDeleteOptions) => RedisCachedScript) {
+  public constructor(generator: (negativeCache: boolean) => RedisCachedScript) {
     this._scripts = [null, null];
     this._generator = generator;
   }
@@ -25,10 +24,10 @@ export class DeleteEntitiesCachedScriptSet implements RedisCachedScriptSet<Persi
   /**
    * @inheritdoc
    */
-  public eval(gArgs: PersistencyDeleteOptions, eArgsGen: (scriptArg: string) => any[]): Promise<any> {
-    const index = gArgs.negativeCache ? 1 : 0;
+  public eval(negativeCache: boolean, eArgsGen: (scriptArg: string) => any[]): Promise<any> {
+    const index = negativeCache ? 1 : 0;
     if (null == this._scripts[index]) {
-      this._scripts[index] = this._generator(gArgs);
+      this._scripts[index] = this._generator(negativeCache);
     }
     return this._scripts[index].eval(eArgsGen);
   }

--- a/src/persistence/scheduler/ant-scheduler-model-manager.ts
+++ b/src/persistence/scheduler/ant-scheduler-model-manager.ts
@@ -53,7 +53,7 @@ export class AntSchedulerModelManager<
   ): MultipleResultPrimaryQueryManager<TEntity> {
     const queryManager = new AntMultipleResultPrimaryQueryManager(
       this._model,
-      this._primaryManager,
+      this,
       query,
       redis,
       reverseHashKey,
@@ -78,7 +78,7 @@ export class AntSchedulerModelManager<
   ): SingleResultPrimaryQueryManager<TEntity> {
     const queryManager = new AntSingleResultPrimaryQueryManager(
       this._model,
-      this._primaryManager,
+      this,
       query,
       redis,
       reverseHashKey,
@@ -101,15 +101,34 @@ export class AntSchedulerModelManager<
     if (deleteOptions.ignorePrimaryLayer) {
       return Promise.resolve();
     } else {
-      return this._primaryManager.delete(id, deleteOptions);
+      return this._primaryManager.delete(id);
     }
   }
 
   /**
    * @inheritdoc
    */
-  public get(id: string | number, options?: Partial<PersistencySearchOptions>): Promise<TEntity> {
-    return this._primaryManager.get(id, new AntJsSearchOptions(options));
+  public async get(id: string | number, options?: Partial<PersistencySearchOptions>): Promise<TEntity> {
+    const searchOptions = new AntJsSearchOptions(options);
+
+    let entity: TEntity;
+
+    if (!searchOptions.ignorePrimaryLayer) {
+      entity = await this._primaryManager.get(id);
+    }
+
+    if (undefined === entity && null != this._secondaryManager && !searchOptions.ignoreSecondaryLayer) {
+      entity = await this._secondaryManager.getById(id);
+      if (!searchOptions.ignorePrimaryLayer) {
+        await this._primaryManager.cacheMiss(id, entity, searchOptions);
+      }
+    }
+
+    if (undefined === entity) {
+      entity = null;
+    }
+
+    return entity;
   }
 
   /**
@@ -123,14 +142,132 @@ export class AntSchedulerModelManager<
     if (deleteOptions.ignorePrimaryLayer) {
       return Promise.resolve();
     } else {
-      return this._primaryManager.mDelete(ids, deleteOptions);
+      return this._primaryManager.mDelete(ids);
     }
   }
 
   /**
    * @inheritdoc
    */
-  public mGet(ids: number[] | string[], options?: Partial<PersistencySearchOptions>): Promise<TEntity[]> {
-    return this._primaryManager.mGet(ids, new AntJsSearchOptions(options));
+  public async mGet(ids: number[] | string[], options?: Partial<PersistencySearchOptions>): Promise<TEntity[]> {
+    const searchOptions = new AntJsSearchOptions(options);
+
+    // Get the different ones.
+    ids = Array.from(new Set<number | string>(ids)) as number[] | string[];
+
+    if (searchOptions.ignorePrimaryLayer) {
+      return this._mGetIgnoringPrimary(ids, searchOptions);
+    }
+
+    const entities = await this._primaryManager.mGet(ids);
+
+    if (null == this._secondaryManager || searchOptions.ignoreSecondaryLayer) {
+      return this._mGetIgnoringSecondary(entities);
+    }
+
+    const missingIds = this._mGetGetMissingIds(ids, entities);
+
+    if (0 === missingIds.length) {
+      return this._mGetIgnoringSecondary(entities);
+    }
+
+    let missingEntities: TEntity[];
+
+    if (this._primaryManager.negativeCache) {
+      missingEntities = await this._mGetGetMissingEntitiesAndCacheMissesWithNegativeStrategy(missingIds, searchOptions);
+    } else {
+      missingEntities = await this._secondaryManager.getByIds(missingIds);
+      await this._primaryManager.cacheMisses(missingIds, missingEntities, searchOptions);
+    }
+
+    return this._mGetBuildResultArray(entities, missingEntities, missingIds);
+  }
+
+  /**
+   * Builds a result array mixing entities obtained from both primary and secondary layers.
+   * @param entities Entities obtained from the primary layer.
+   * @param missingEntities Entities obtained from the secondary layer.
+   * @param missingIds Missing ids from the primary layer.
+   * @returns Result array generated.
+   */
+  private _mGetBuildResultArray(
+    entities: TEntity[],
+    missingEntities: TEntity[],
+    missingIds: number[] | string[],
+  ): TEntity[] {
+    const results = new Array(entities.length - missingIds.length + missingEntities.length);
+    let counter = 0;
+    for (const entity of entities) {
+      if (null != entity) {
+        results[counter++] = entity;
+      }
+    }
+    for (const entity of missingEntities) {
+      results[counter++] = entity;
+    }
+    return results;
+  }
+
+  /**
+   * Gets missing entites from the secondary layer and permorms cache operations at the primary layer.
+   * @param missingIds Missing ids from the primary layer.
+   * @param options Search options.
+   * @returns Missing entities from the secondary layer.
+   */
+  private async _mGetGetMissingEntitiesAndCacheMissesWithNegativeStrategy(
+    missingIds: number[] | string[],
+    options: PersistencySearchOptions,
+  ): Promise<TEntity[]> {
+    const missingEntities = await this._secondaryManager.getByIdsOrderedAsc(missingIds);
+
+    const sortedIds =
+      'number' === typeof missingIds[0]
+        ? (missingIds as number[]).sort((a: number, b: number) => a - b)
+        : missingIds.sort();
+
+    await this._primaryManager.cacheMisses(sortedIds, missingEntities, options);
+    return missingEntities;
+  }
+
+  /**
+   * Gets the missing ids given a set of requested ids and a set of entities found.
+   * @param ids Requested ids to the primary layer.
+   * @param entities Entities found.
+   */
+  private _mGetGetMissingIds(ids: number[] | string[], entities: TEntity[]): number[] | string[] {
+    const missingIds: number[] | string[] = new Array();
+    for (let i = 0; i < entities.length; ++i) {
+      if (undefined === entities[i]) {
+        (missingIds as Array<number | string>).push(ids[i]);
+      }
+    }
+    return missingIds;
+  }
+
+  /**
+   * Gets entities by ids ignoring the primary layer.
+   * @param ids Entity's ids.
+   * @param options Search options.
+   * @returns Entities found.
+   */
+  private _mGetIgnoringPrimary(ids: number[] | string[], options: PersistencySearchOptions): Promise<TEntity[]> {
+    return null == this._secondaryManager || options.ignoreSecondaryLayer ?
+      Promise.resolve(new Array()) :
+      this._secondaryManager.getByIds(ids);
+  }
+
+  /**
+   * Filters entities from the output of the primary layer
+   * @param entities Entities found at primary layer.
+   * @returns Filtered entities.
+   */
+  private _mGetIgnoringSecondary(entities: TEntity[]): TEntity[] {
+    const results = new Array();
+    for (const entity of entities) {
+      if (null != entity) {
+        results.push(entity);
+      }
+    }
+    return results;
   }
 }

--- a/src/persistence/scheduler/ant-scheduler-model-manager.ts
+++ b/src/persistence/scheduler/ant-scheduler-model-manager.ts
@@ -251,9 +251,9 @@ export class AntSchedulerModelManager<
    * @returns Entities found.
    */
   private _mGetIgnoringPrimary(ids: number[] | string[], options: PersistencySearchOptions): Promise<TEntity[]> {
-    return null == this._secondaryManager || options.ignoreSecondaryLayer ?
-      Promise.resolve(new Array()) :
-      this._secondaryManager.getByIds(ids);
+    return null == this._secondaryManager || options.ignoreSecondaryLayer
+      ? Promise.resolve(new Array())
+      : this._secondaryManager.getByIds(ids);
   }
 
   /**

--- a/src/test/api/query/ant-query-manager-test.ts
+++ b/src/test/api/query/ant-query-manager-test.ts
@@ -1,10 +1,12 @@
 import { AntModel } from '../../../model/ant-model';
 import { AntPrimaryModelManager } from '../../../persistence/primary/ant-primary-model-manager';
+import { AntSchedulerModelManager } from '../../../persistence/scheduler/ant-scheduler-model-manager';
 import { ApiQueryManager } from '../../../api/query/api-query-manager';
 import { Entity } from '../../../model/entity';
 import { MinimalAntQueryManager } from './minimal-ant-query-manager';
 import { Model } from '../../../model/model';
 import { RedisWrapper } from '../../primary/redis-wrapper';
+import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 import { SingleResultQueryByFieldManager } from '../../primary/query/single-result-query-by-field-manager';
 import { Test } from '../../../testapi/api/test';
 
@@ -63,9 +65,12 @@ export class AntQueryManagerTest implements Test {
       async (done) => {
         const model: Model<EntityTest> = modelGenerator(prefix);
         const primaryManager = new AntPrimaryModelManager(model, this._redis.redis, true);
+        const schedulerManager = new AntSchedulerModelManager(model, primaryManager) as SchedulerModelManager<
+          EntityTest
+        >;
         const queryManager = new SingleResultQueryByFieldManager<EntityTest>(
           model,
-          primaryManager,
+          schedulerManager,
           async () => null,
           this._redis.redis,
           prefix + 'reverse/',

--- a/src/test/primary/primary-entity-manager-for-test.ts
+++ b/src/test/primary/primary-entity-manager-for-test.ts
@@ -1,11 +1,7 @@
 import { AntPrimaryEntityManager } from '../../persistence/primary/ant-primary-entity-manager';
 import { Entity } from '../../model/entity';
-import { SecondaryEntityManager } from '../../persistence/secondary/secondary-entity-manager';
 
-export class PrimaryEntityManagerForTest<
-  TEntity extends Entity,
-  TSecondaryManager extends SecondaryEntityManager<TEntity>
-> extends AntPrimaryEntityManager<TEntity, TSecondaryManager> {
+export class PrimaryEntityManagerForTest<TEntity extends Entity> extends AntPrimaryEntityManager<TEntity> {
   public getKey(id: number | string): string {
     return this._getKey(id);
   }

--- a/src/test/primary/primary-entity-manager-test.ts
+++ b/src/test/primary/primary-entity-manager-test.ts
@@ -440,12 +440,12 @@ export class PrimaryEntityManagerTest implements Test {
         await primaryManager.cacheMiss(
           entity[model.id],
           entity,
-          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, },
-        ));
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000 }),
+        );
         await primaryManager.cacheMiss(
           entity[model.id],
           null,
-          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, }),
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000 }),
         );
         const entityFound = await primaryManager.get(entity[model.id]);
         expect(entityFound).toBeNull();
@@ -471,8 +471,8 @@ export class PrimaryEntityManagerTest implements Test {
         await primaryManager.cacheMiss(
           entity[model.id],
           entity,
-          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite },
-        ));
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite }),
+        );
         await primaryManager.cacheMiss(
           entity[model.id],
           null,
@@ -500,8 +500,9 @@ export class PrimaryEntityManagerTest implements Test {
           id: 1,
         };
         await primaryManager.cacheMiss(
-          entity[model.id], entity,
-          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, }),
+          entity[model.id],
+          entity,
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000 }),
         );
         const entityFound = await primaryManager.get(entity[model.id]);
         expect(entityFound).toEqual(entity);
@@ -572,12 +573,12 @@ export class PrimaryEntityManagerTest implements Test {
         await primaryManager.cacheMisses(
           [entity[model.id]],
           [entity],
-          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, },
-        ));
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000 }),
+        );
         await primaryManager.cacheMisses(
           [entity[model.id]],
           new Array(),
-          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, }),
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000 }),
         );
         const entityFound = await primaryManager.get(entity[model.id]);
         expect(entityFound).toBeNull();
@@ -603,8 +604,8 @@ export class PrimaryEntityManagerTest implements Test {
         await primaryManager.cacheMisses(
           [entity[model.id]],
           [entity],
-          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite },
-        ));
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite }),
+        );
         await primaryManager.cacheMisses(
           [entity[model.id]],
           [],
@@ -632,8 +633,9 @@ export class PrimaryEntityManagerTest implements Test {
           id: 1,
         };
         await primaryManager.cacheMisses(
-          [entity[model.id]], [entity],
-          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, }),
+          [entity[model.id]],
+          [entity],
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000 }),
         );
         const entityFound = await primaryManager.get(entity[model.id]);
         expect(entityFound).toEqual(entity);

--- a/src/test/primary/primary-entity-manager-test.ts
+++ b/src/test/primary/primary-entity-manager-test.ts
@@ -53,6 +53,16 @@ export class PrimaryEntityManagerTest implements Test {
       this._itInvokesPrimaryToEntityAtGet();
       this._itInvokesPrimaryToEntityAtMGet();
       this._itMustBeInitializable();
+      this._itMustCacheAnEntity();
+      this._itMustCacheAnEntityDeletingAMissingEntity();
+      this._itMustCacheAnEntityDeletingAMissingEntityWithCacheAndOverwriteModeAndTtl();
+      this._itMustCacheAnEntityDeletingAMissingEntityWithNoCacheMode();
+      this._itMustCacheAnEntityWithCacheAndOverWriteModeAndTTL();
+      this._itMustCacheMultipleEntities();
+      this._itMustCacheMultipleEntitiesDeletingMissingEntity();
+      this._itMustCacheMultipleEntitiesDeletingAMissingEntityWithCacheAndOverwriteModeAndTtl();
+      this._itMustCacheMultipleEntitiesDeletingAMissingEntityWithNoCacheMode();
+      this._itMustCacheMultipleEntitiesWithCacheAndOverWriteModeAndTTL();
       this._itMustFindAnEntityAtCache();
       this._itMustFindNullIfNullIdIsProvided();
       this._itMustFindMultipleEntitiesAtCache();
@@ -363,6 +373,270 @@ export class PrimaryEntityManagerTest implements Test {
         expect(() => {
           new AntPrimaryEntityManager(model, this._redis.redis, true);
         }).not.toThrowError();
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
+  }
+
+  private _itMustCacheAnEntity(): void {
+    const itsName = 'mustCacheAnEntity';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(
+      itsName,
+      async (done) => {
+        await this._beforeAllPromise;
+        const model = new AntModel<EntityTest>('id', { prefix });
+        const primaryManager = new AntPrimaryEntityManager<EntityTest>(model, this._redis.redis, true);
+        const entity: EntityTest = {
+          field: 'sample-field',
+          id: 1,
+        };
+        await primaryManager.cacheMiss(entity[model.id], entity, new AntJsSearchOptions());
+        const entityFound = await primaryManager.get(entity[model.id]);
+        expect(entityFound).toEqual(entity);
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
+  }
+
+  private _itMustCacheAnEntityDeletingAMissingEntity(): void {
+    const itsName = 'mustCacheAnEntityDeletingAMissingEntity';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(
+      itsName,
+      async (done) => {
+        await this._beforeAllPromise;
+        const model = new AntModel<EntityTest>('id', { prefix });
+        const primaryManager = new AntPrimaryEntityManager<EntityTest>(model, this._redis.redis, true);
+        const entity: EntityTest = {
+          field: 'sample-field',
+          id: 1,
+        };
+        await primaryManager.cacheMiss(entity[model.id], entity, new AntJsSearchOptions());
+        await primaryManager.cacheMiss(entity[model.id], null, new AntJsSearchOptions());
+        const entityFound = await primaryManager.get(entity[model.id]);
+        expect(entityFound).toBeNull();
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
+  }
+
+  private _itMustCacheAnEntityDeletingAMissingEntityWithCacheAndOverwriteModeAndTtl(): void {
+    const itsName = 'mustCacheAnEntityDeletingAMissingEntityWithCacheAndOverwriteModeAndTtl';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(
+      itsName,
+      async (done) => {
+        await this._beforeAllPromise;
+        const model = new AntModel<EntityTest>('id', { prefix });
+        const primaryManager = new AntPrimaryEntityManager<EntityTest>(model, this._redis.redis, true);
+        const entity: EntityTest = {
+          field: 'sample-field',
+          id: 1,
+        };
+        await primaryManager.cacheMiss(
+          entity[model.id],
+          entity,
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, },
+        ));
+        await primaryManager.cacheMiss(
+          entity[model.id],
+          null,
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, }),
+        );
+        const entityFound = await primaryManager.get(entity[model.id]);
+        expect(entityFound).toBeNull();
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
+  }
+
+  private _itMustCacheAnEntityDeletingAMissingEntityWithNoCacheMode(): void {
+    const itsName = 'mustCacheAnEntityDeletingAMissingEntityWithNoCacheMode';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(
+      itsName,
+      async (done) => {
+        await this._beforeAllPromise;
+        const model = new AntModel<EntityTest>('id', { prefix });
+        const primaryManager = new AntPrimaryEntityManager<EntityTest>(model, this._redis.redis, true);
+        const entity: EntityTest = {
+          field: 'sample-field',
+          id: 1,
+        };
+        await primaryManager.cacheMiss(
+          entity[model.id],
+          entity,
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite },
+        ));
+        await primaryManager.cacheMiss(
+          entity[model.id],
+          null,
+          new AntJsSearchOptions({ cacheMode: CacheMode.NoCache }),
+        );
+        const entityFound = await primaryManager.get(entity[model.id]);
+        expect(entityFound).toEqual(entity);
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
+  }
+
+  private _itMustCacheAnEntityWithCacheAndOverWriteModeAndTTL(): void {
+    const itsName = 'mustCacheAnEntityWithCacheAndOverWriteModeAndTTL';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(
+      itsName,
+      async (done) => {
+        await this._beforeAllPromise;
+        const model = new AntModel<EntityTest>('id', { prefix });
+        const primaryManager = new AntPrimaryEntityManager<EntityTest>(model, this._redis.redis, true);
+        const entity: EntityTest = {
+          field: 'sample-field',
+          id: 1,
+        };
+        await primaryManager.cacheMiss(
+          entity[model.id], entity,
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, }),
+        );
+        const entityFound = await primaryManager.get(entity[model.id]);
+        expect(entityFound).toEqual(entity);
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
+  }
+
+  private _itMustCacheMultipleEntities(): void {
+    const itsName = 'mustCacheMultipleEntities';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(
+      itsName,
+      async (done) => {
+        await this._beforeAllPromise;
+        const model = new AntModel<EntityTest>('id', { prefix });
+        const primaryManager = new AntPrimaryEntityManager<EntityTest>(model, this._redis.redis, true);
+        const entity: EntityTest = {
+          field: 'sample-field',
+          id: 1,
+        };
+        await primaryManager.cacheMisses([entity[model.id]], [entity], new AntJsSearchOptions());
+        const entityFound = await primaryManager.get(entity[model.id]);
+        expect(entityFound).toEqual(entity);
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
+  }
+
+  private _itMustCacheMultipleEntitiesDeletingMissingEntity(): void {
+    const itsName = 'mustCacheMultipleEntitiesDeletingAMissingEntity';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(
+      itsName,
+      async (done) => {
+        await this._beforeAllPromise;
+        const model = new AntModel<EntityTest>('id', { prefix });
+        const primaryManager = new AntPrimaryEntityManager<EntityTest>(model, this._redis.redis, true);
+        const entity: EntityTest = {
+          field: 'sample-field',
+          id: 1,
+        };
+        await primaryManager.cacheMisses([entity[model.id]], [entity], new AntJsSearchOptions());
+        await primaryManager.cacheMisses([entity[model.id]], new Array(), new AntJsSearchOptions());
+        const entityFound = await primaryManager.get(entity[model.id]);
+        expect(entityFound).toBeNull();
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
+  }
+
+  private _itMustCacheMultipleEntitiesDeletingAMissingEntityWithCacheAndOverwriteModeAndTtl(): void {
+    const itsName = 'mustCacheMultipleEntitiesDeletingAMissingEntityWithCacheAndOverwriteModeAndTtl';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(
+      itsName,
+      async (done) => {
+        await this._beforeAllPromise;
+        const model = new AntModel<EntityTest>('id', { prefix });
+        const primaryManager = new AntPrimaryEntityManager<EntityTest>(model, this._redis.redis, true);
+        const entity: EntityTest = {
+          field: 'sample-field',
+          id: 1,
+        };
+        await primaryManager.cacheMisses(
+          [entity[model.id]],
+          [entity],
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, },
+        ));
+        await primaryManager.cacheMisses(
+          [entity[model.id]],
+          new Array(),
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, }),
+        );
+        const entityFound = await primaryManager.get(entity[model.id]);
+        expect(entityFound).toBeNull();
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
+  }
+
+  private _itMustCacheMultipleEntitiesDeletingAMissingEntityWithNoCacheMode(): void {
+    const itsName = 'mustCacheMultipleEntitiesDeletingAMissingEntityWithNoCacheMode';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(
+      itsName,
+      async (done) => {
+        await this._beforeAllPromise;
+        const model = new AntModel<EntityTest>('id', { prefix });
+        const primaryManager = new AntPrimaryEntityManager<EntityTest>(model, this._redis.redis, true);
+        const entity: EntityTest = {
+          field: 'sample-field',
+          id: 1,
+        };
+        await primaryManager.cacheMisses(
+          [entity[model.id]],
+          [entity],
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite },
+        ));
+        await primaryManager.cacheMisses(
+          [entity[model.id]],
+          [],
+          new AntJsSearchOptions({ cacheMode: CacheMode.NoCache }),
+        );
+        const entityFound = await primaryManager.get(entity[model.id]);
+        expect(entityFound).toEqual(entity);
+        done();
+      },
+      MAX_SAFE_TIMEOUT,
+    );
+  }
+
+  private _itMustCacheMultipleEntitiesWithCacheAndOverWriteModeAndTTL(): void {
+    const itsName = 'mustCacheMultipleEntitiesWithCacheAndOverWriteModeAndTTL';
+    const prefix = this._declareName + '/' + itsName + '/';
+    it(
+      itsName,
+      async (done) => {
+        await this._beforeAllPromise;
+        const model = new AntModel<EntityTest>('id', { prefix });
+        const primaryManager = new AntPrimaryEntityManager<EntityTest>(model, this._redis.redis, true);
+        const entity: EntityTest = {
+          field: 'sample-field',
+          id: 1,
+        };
+        await primaryManager.cacheMisses(
+          [entity[model.id]], [entity],
+          new AntJsSearchOptions({ cacheMode: CacheMode.CacheAndOverwrite, ttl: 10000, }),
+        );
+        const entityFound = await primaryManager.get(entity[model.id]);
+        expect(entityFound).toEqual(entity);
         done();
       },
       MAX_SAFE_TIMEOUT,

--- a/src/test/primary/query/multiple-result-query-by-field-manager.ts
+++ b/src/test/primary/query/multiple-result-query-by-field-manager.ts
@@ -2,8 +2,8 @@ import { TMQuery, TQuery } from '../../../persistence/primary/query/query-types'
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
-import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
+import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 
 export class MultipleResultQueryByFieldManager<TEntity extends Entity> extends AntMultipleResultPrimaryQueryManager<
   TEntity
@@ -22,7 +22,7 @@ export class MultipleResultQueryByFieldManager<TEntity extends Entity> extends A
    */
   public constructor(
     model: Model<TEntity>,
-    manager: PrimaryEntityManager<TEntity>,
+    manager: SchedulerModelManager<TEntity>,
     query: TQuery<number[] | string[]>,
     redis: RedisMiddleware,
     reverseHashKey: string,

--- a/src/test/primary/query/names-starting-by-letter-alternative.ts
+++ b/src/test/primary/query/names-starting-by-letter-alternative.ts
@@ -2,8 +2,8 @@ import * as _ from 'lodash';
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
-import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
+import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 import { SecondaryEntityManagerMock } from '../../../testapi/api/secondary/secondary-entity-manager-mock';
 import { iterableFilter } from '../../util/iterable-filter';
 
@@ -20,7 +20,7 @@ export class NamesStartingByLetterAlternative extends AntMultipleResultPrimaryQu
    */
   public constructor(
     model: Model<NamedEntityAlternative>,
-    manager: PrimaryEntityManager<NamedEntityAlternative>,
+    manager: SchedulerModelManager<NamedEntityAlternative>,
     secondaryModelManagerMock: SecondaryEntityManagerMock<NamedEntityAlternative>,
     redis: RedisMiddleware,
     reverseHashKey: string,

--- a/src/test/primary/query/names-starting-by-letter.ts
+++ b/src/test/primary/query/names-starting-by-letter.ts
@@ -2,8 +2,8 @@ import * as _ from 'lodash';
 import { AntMultipleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-multiple-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
-import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
+import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 import { SecondaryEntityManagerMock } from '../../../testapi/api/secondary/secondary-entity-manager-mock';
 import { iterableFilter } from '../../util/iterable-filter';
 
@@ -24,7 +24,7 @@ export class NamesStartingByLetter extends AntMultipleResultPrimaryQueryManager<
    */
   public constructor(
     model: Model<NamedEntity>,
-    manager: PrimaryEntityManager<NamedEntity>,
+    manager: SchedulerModelManager<NamedEntity>,
     secondaryModelManagerMock: SecondaryEntityManagerMock<NamedEntity>,
     redis: RedisMiddleware,
     reverseHashKey: string,

--- a/src/test/primary/query/single-result-query-by-field-manager.ts
+++ b/src/test/primary/query/single-result-query-by-field-manager.ts
@@ -1,8 +1,8 @@
 import { AntSingleResultPrimaryQueryManager } from '../../../persistence/primary/query/ant-single-result-primary-query-manager';
 import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
-import { PrimaryEntityManager } from '../../../persistence/primary/primary-entity-manager';
 import { RedisMiddleware } from '../../../persistence/primary/redis-middleware';
+import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 
 export class SingleResultQueryByFieldManager<TEntity extends Entity> extends AntSingleResultPrimaryQueryManager<
   TEntity
@@ -21,7 +21,7 @@ export class SingleResultQueryByFieldManager<TEntity extends Entity> extends Ant
    */
   public constructor(
     model: Model<TEntity>,
-    manager: PrimaryEntityManager<TEntity>,
+    manager: SchedulerModelManager<TEntity>,
     query: (params: any) => Promise<number | string>,
     redis: RedisMiddleware,
     reverseHashKey: string,

--- a/src/test/scheduler/ant-scheduler-mode-manager-test.ts
+++ b/src/test/scheduler/ant-scheduler-mode-manager-test.ts
@@ -51,28 +51,20 @@ export class AntSchedulerModelManagerTest implements Test {
 
         const methodsToTest: Array<keyof PrimaryModelManager<any>> = ['delete', 'get', 'mDelete', 'mGet'];
         for (const methodToTest of methodsToTest) {
-          spyOn(primaryManager, methodToTest as any).and.returnValue(Promise.resolve(methodToTest) as any);
+          spyOn(primaryManager, methodToTest as any).and.callThrough();
         }
 
         const entity: Entity = { id: 0 };
 
-        const [deleteResult, getResult, mDeleteResult, mGetResult] = await Promise.all([
+        await Promise.all([
           schedulerModelManager.delete(entity.id),
           schedulerModelManager.get(entity.id),
           schedulerModelManager.mDelete([entity.id]),
           schedulerModelManager.mGet([entity.id]),
         ]);
 
-        const results: { [key: string]: any } = {
-          delete: deleteResult,
-          get: getResult,
-          mDelete: mDeleteResult,
-          mGet: mGetResult,
-        };
-
         for (const methodToTest of methodsToTest) {
           expect(primaryManager[methodToTest]).toHaveBeenCalled();
-          expect(results[methodToTest]).toBe(methodToTest);
         }
 
         done();
@@ -82,7 +74,7 @@ export class AntSchedulerModelManagerTest implements Test {
   }
 
   private _itMustCallPrimaryManagerMethodsEvenIfNoSecondaryManagerIsProvided(): void {
-    const itsName = 'must call primary manager methods';
+    const itsName = 'must call primary manager methods even if no secondary manager is provided';
     const prefix = this._declareName + '/' + itsName + '/';
     it(
       itsName,
@@ -93,28 +85,20 @@ export class AntSchedulerModelManagerTest implements Test {
 
         const methodsToTest: Array<keyof PrimaryModelManager<any>> = ['delete', 'get', 'mDelete', 'mGet'];
         for (const methodToTest of methodsToTest) {
-          spyOn(primaryManager, methodToTest as any).and.returnValue(Promise.resolve(methodToTest) as any);
+          spyOn(primaryManager, methodToTest as any).and.callThrough();
         }
 
         const entity: Entity = { id: 0 };
 
-        const [deleteResult, getResult, mDeleteResult, mGetResult] = await Promise.all([
+        await Promise.all([
           schedulerModelManager.delete(entity.id),
           schedulerModelManager.get(entity.id),
           schedulerModelManager.mDelete([entity.id]),
           schedulerModelManager.mGet([entity.id]),
         ]);
 
-        const results: { [key: string]: any } = {
-          delete: deleteResult,
-          get: getResult,
-          mDelete: mDeleteResult,
-          mGet: mGetResult,
-        };
-
         for (const methodToTest of methodsToTest) {
           expect(primaryManager[methodToTest]).toHaveBeenCalled();
-          expect(results[methodToTest]).toBe(methodToTest);
         }
 
         done();

--- a/src/testapi/api/generator/antjs-model-manager-generator.ts
+++ b/src/testapi/api/generator/antjs-model-manager-generator.ts
@@ -1,4 +1,5 @@
 import { AntPrimaryModelManager } from '../../../persistence/primary/ant-primary-model-manager';
+import { AntSchedulerModelManager } from '../../../persistence/scheduler/ant-scheduler-model-manager';
 import { ApiModelManagerGeneratorOptions } from './api-model-manager-generator-options';
 import { ApiModelManagerGeneratorRedisOptions } from './api-model-manager-generator-redis-options';
 import { ApiModelManagerGeneratorSecodaryManagerOptions } from './api-model-manager-generator-secodary-manager-options';
@@ -6,6 +7,7 @@ import { Entity } from '../../../model/entity';
 import { Model } from '../../../model/model';
 import { ModelManagerGenerator } from './model-manager-generator';
 import { PrimaryModelManager } from '../../../persistence/primary/primary-model-manager';
+import { SchedulerModelManager } from '../../../persistence/scheduler/scheduler-model-manager';
 import { SecondaryEntityManagerMock } from '../secondary/secondary-entity-manager-mock';
 
 type TModelManagerOptions = ApiModelManagerGeneratorOptions<
@@ -17,7 +19,8 @@ type TModelManagerOptions = ApiModelManagerGeneratorOptions<
 export class AntJsModelManagerGenerator extends ModelManagerGenerator<
   TModelManagerOptions,
   PrimaryModelManager<Entity>,
-  SecondaryEntityManagerMock<Entity>
+  SecondaryEntityManagerMock<Entity>,
+  SchedulerModelManager<Entity>
 > {
   /**
    * @inheritdoc
@@ -29,16 +32,20 @@ export class AntJsModelManagerGenerator extends ModelManagerGenerator<
   /**
    * @inheritdoc
    */
-  protected _generateModelManager(
-    options: TModelManagerOptions,
-    secondaryManager: SecondaryEntityManagerMock<Entity>,
-  ): PrimaryModelManager<Entity> {
+  protected _generateModelManager(options: TModelManagerOptions): PrimaryModelManager<Entity> {
     return new AntPrimaryModelManager(
       options.model,
       options.redisOptions.redis,
       options.redisOptions.useEntityNegativeCache ?? true,
-      secondaryManager,
     );
+  }
+
+  protected _generateSchedulerManager(
+    model: Model<Entity>,
+    primaryManager: PrimaryModelManager<Entity>,
+    secondaryManager: SecondaryEntityManagerMock<Entity>,
+  ): SchedulerModelManager<Entity> {
+    return new AntSchedulerModelManager(model, primaryManager, secondaryManager);
   }
 
   /**


### PR DESCRIPTION
- [x] Primary entity manager no longer calls secondary layer methods.
- [x] Added logic to the scheduler manager in order to perform search operations with both primary and secondary layers.
- [x] Delete options no longer has a negative cache property. The entity manager is the one who decides this.
- [x] Added a public negativeCache property to the entity manager.
- [x] Any query manager requires an scheduler manager instead of an entity manager in order to perform queries.
- [x] Tests have been updated.
- [x] Add tests to cover some missing corner cases